### PR TITLE
Add PMX monitoring for use with https://keymetrics.io/

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,14 @@
 var version = "0.1.3-beta";
 
 var debug = require('debug')('pagermon:server');
+var pmx = require('pmx').init({
+    http          : true, // HTTP routes logging (default: true)
+    ignore_routes : [/socket\.io/, /notFound/], // Ignore http routes with this pattern (Default: [])
+    errors        : true, // Exceptions logging (default: true)
+    custom_probes : true, // Auto expose JS Loop Latency and HTTP req/s as custom metrics
+    network       : true, // Network monitoring at the application level
+    ports         : true  // Shows which ports your app is listening on (default: false)
+});
 var http = require('http');
 var compression = require('compression');
 var express = require('express');
@@ -67,7 +75,7 @@ var app = express();
     // view engine setup
     app.set('views', path.join(__dirname, 'views'));
     app.set('view engine', 'ejs');
-    app.set('trust proxy', 'loopback, linklocal, uniquelocal');    
+    app.set('trust proxy', 'loopback, linklocal, uniquelocal');
 
 var server = http.createServer(app);
 var io = require('socket.io').listen(server);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagermon",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "private": true,
   "license": "Unlicense",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -39,9 +39,9 @@
     "underscore": "^1.8.3",
     "zone.js": "^0.8.12",
     "pmx": "latest"
-  }
+  },
   "repository": {
   "type": "git",
   "url": "https://github.com/davidmckenzie/pagermon.git"
-}
+ }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,11 @@
     "sqlite3": "~3.1.8",
     "systemjs": "^0.20.13",
     "underscore": "^1.8.3",
-    "zone.js": "^0.8.12"
+    "zone.js": "^0.8.12",
+    "pmx": "latest"
   }
+  "repository": {
+  "type": "git",
+  "url": "https://github.com/davidmckenzie/pagermon.git"
+}
 }


### PR DESCRIPTION
Simply adds requirements to use PM2's Key Metrics monitoring service. 

Requires user's to re-run `npm install` to download the required module.
This will have no effect on new installs. 