### PR TITLE
Email/SMTP intergration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The UI is built around a Node/Express/Angular/Bootstrap stack, while the client 
 * Pretty HTML5
 * Native browner notifications
 * [Pushover](https://pushover.net/) Integration - near realtime muti-device notification service
+* SMTP/Email support
 * May or may not contain cute puppies
 
 ### Planned Features
@@ -69,7 +70,7 @@ These instructions will get you a copy of the project up and running on your loc
     $ sudo apt-get install npm sqlite3
     $ npm install npm@latest -g
     $ npm install pm2 -g
-    $ npm install 
+    $ npm install
     $ export NODE_ENV=production
     $ pm2 start server/process.json
 ```
@@ -121,7 +122,7 @@ All are welcome to contribute.
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/davidmckenzie/pagermon/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/davidmckenzie/pagermon/tags).
 
 ## Authors
 

--- a/server/app.js
+++ b/server/app.js
@@ -42,6 +42,7 @@ var db = new sqlite3.Database('./messages.db', sqlite3.OPEN_READWRITE | sqlite3.
           sql += "icon TEXT, ";
           sql += "color TEXT, ";
           sql += "push INTEGER DEFAULT 0, ";
+          sql += "pushpri TEXT, ";
           sql += "mailenable INTEGER DEFAULT 0, ";
           sql += "mailto TEXT, ";
           sql += "ignore INTEGER DEFAULT 0 ); ";

--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,4 @@
-var version = "0.1.4-beta";
+var version = "0.1.5-beta";
 
 var debug = require('debug')('pagermon:server');
 var pmx = require('pmx').init({
@@ -33,7 +33,7 @@ process.on('SIGINT', function() {
 var sqlite3 = require('sqlite3').verbose();
 var db = new sqlite3.Database('./messages.db', sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE, function (err) {
     if (err) { console.log(err.message); } else {
-      
+
       var sql =  "CREATE TABLE IF NOT EXISTS capcodes ( ";
 	        sql += "id INTEGER PRIMARY KEY AUTOINCREMENT, ";
           sql += "address TEXT NOT NULL, ";
@@ -42,6 +42,8 @@ var db = new sqlite3.Database('./messages.db', sqlite3.OPEN_READWRITE | sqlite3.
           sql += "icon TEXT, ";
           sql += "color TEXT, ";
           sql += "push INTEGER DEFAULT 0, ";
+          sql += "mailenable INTEGER DEFAULT 0, ";
+          sql += "mailto TEXT, ";
           sql += "ignore INTEGER DEFAULT 0 ); ";
           sql += "CREATE TABLE IF NOT EXISTS messages ( ";
           sql += "id INTEGER UNIQUE, ";
@@ -54,7 +56,7 @@ var db = new sqlite3.Database('./messages.db', sqlite3.OPEN_READWRITE | sqlite3.
           sql += "CREATE INDEX IF NOT EXISTS `msg_index` ON `messages` (`address`,`id` DESC); ";
           sql += "CREATE INDEX IF NOT EXISTS `msg_alias` ON `messages` (`id` DESC, `alias_id`); ";
           sql += "CREATE UNIQUE INDEX IF NOT EXISTS `cc_pk_idx` ON `capcodes` (`id`,`address` DESC); ";
-          
+
       db.serialize(() => {
           db.exec(sql, function(err) {
               if (err) { console.log(err); }

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -48,8 +48,7 @@
     "pushenable": false,
     "pushAPIKEY":  "",
     "pushgroup":   "",
-    "pushSound": "pushover",
-    "pushPriority": "0"
+    "pushSound": "pushover"
   },
   "STMP":{
     "MailEnable": false,

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -50,5 +50,15 @@
     "pushgroup":   "",
     "pushSound": "pushover",
     "pushPriority": "0"
+  },
+  "STMP":{
+    "MailEnable": false,
+    "MailFrom": "",
+    "MailFromName": "",
+    "SMTPServer":  "",
+    "SMTPPort":   "",
+    "STMPUsername": "",
+    "STMPPassword": "",
+    "STMPSecure": true
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagermon",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "license": "Unlicense",
   "scripts": {
@@ -39,7 +39,8 @@
     "underscore": "^1.8.3",
     "zone.js": "^0.8.12",
     "pmx": "latest",
-    "pushover-notifications": "latest"
+    "pushover-notifications": "latest",
+    "nodemailer": "latest"
   },
   "repository": {
     "type": "git",

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -92,6 +92,27 @@
               </div>
             </div>
 
+            <div class="form-group">
+              <label for="alias.mailenable" class="col-xs-4 col-sm-3 control-label">Email</label>
+              <div class="col-xs-8 col-sm-9">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" name="alias.mailenable" ng-model="alias.mailenable" ng-true-value="1" ng-false-value="0">
+                    Enable sending via SMTP
+                  </label>
+                  <span id="helpBlock" class="help-block">If checked, messages matching this alias will be sent via SMTP</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpeiants</label>
+              <div class="col-xs-8 col-sm-9">
+              <input class="form-control" type="text" name="alias.mailto" ng-model="alias.mailto">
+              <span id="helpBlock" class="help-block">Recpeiants for this capcode, comma separated</span>
+              </div>
+            </div>
+
             <div class="form-group" ng-class="{'has-warning':alias.push == 1}">
               <label for="alias.push" class="col-xs-4 col-sm-3 control-label">Pushover</label>
               <div class="col-xs-8 col-sm-9">
@@ -113,4 +134,3 @@
           </form>
         </div>
 </div>
-

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -113,7 +113,7 @@
               </div>
             </div>
 
-            <div class="form-group" ng-class="{'has-warning':alias.push == 1}">
+            <div class="form-group">
               <label for="alias.push" class="col-xs-4 col-sm-3 control-label">Pushover</label>
               <div class="col-xs-8 col-sm-9">
                 <div class="checkbox">
@@ -123,6 +123,19 @@
                   </label>
                   <span id="helpBlock" class="help-block">If checked, messages matching this alias will be sent via pushover</span>
                 </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="alias.pushpri" class="col-xs-4 col-sm-3 control-label">Pushover - Priority</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="alias.pushpri" ng-model="alias.pushpri" class="form-control">
+                  <option value="-2">Lowest Priority</option>
+                  <option value="-1">Low Priority</option>
+                  <option value="0">Normal Priority</option>
+                  <option value="1">High Priority</option>
+                  <option value="2">Emergency Priority</option>
+                </select>
+                <span id="helpBlock" class="help-block">Set's the priority messages will be sent at. More information can be found here <a href="https://pushover.net/api#priority">https://pushover.net/api#priority</a></span>
               </div>
             </div>
 

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -10,7 +10,7 @@
           <h4 style="padding-left: 15px;"><a href="/admin/">Admin</a> / Settings</h4>
           <hr />
           <form ng-submit="settingsSubmit()" class="form-horizontal" style="padding-bottom: 70px;">
-            
+
             <h5>Global</h5>
             <div class="form-group">
               <label for="global.loglevel" class="col-xs-4 col-sm-3 control-label">Log level</label>
@@ -35,7 +35,7 @@
                 <span id="helpBlock" class="help-block">Secret key for cookie sessions, should be changed before deploying the application. Changing this will invalidate existing sessions.</span>
               </div>
             </div>
-            
+
             <h5>Database</h5>
             <fieldset disabled>
             <div class="form-group">
@@ -82,7 +82,7 @@
               </div>
             </div>
             </fieldset>
-            
+
             <h5>Messages</h5>
             <div class="form-group">
               <label for="messages.maxLimit" class="col-xs-4 col-sm-3 control-label">Max limit per page</label>
@@ -239,7 +239,76 @@
                 <span id="helpBlock" class="help-block">Sets the Application Sound</span>
               </div>
             </div>
-            
+
+
+
+            <h5>Email</h5>
+            <div class="form-group">
+              <label for="STMP.MailEnable" class="col-xs-4 col-sm-3 control-label">Enable</label>
+              <div class="col-xs-8 col-sm-9">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" name="STMP.MailEnable" ng-model="settings.STMP.MailEnable">
+                    Enable or disable for selected alias's
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.MailFrom" class="col-xs-4 col-sm-3 control-label">Mail from address</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.MailFrom" ng-model="settings.STMP.MailFrom">
+                <span id="helpBlock" class="help-block">Mail will be sent form this address</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.MailFromName" class="col-xs-4 col-sm-3 control-label">From Name</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.MailFromName" ng-model="settings.STMP.MailFromName">
+                <span id="helpBlock" class="help-block">Name to appear from</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.SMTPServer" class="col-xs-4 col-sm-3 control-label">SMTP Server</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.SMTPServer" ng-model="settings.STMP.SMTPServer">
+                <span id="helpBlock" class="help-block">SMTP Server to connect to</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.SMTPPort" class="col-xs-4 col-sm-3 control-label">SMTP Port</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.SMTPPort" ng-model="settings.STMP.SMTPPort">
+                <span id="helpBlock" class="help-block">SMTP Server port to connect to</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.STMPUsername" class="col-xs-4 col-sm-3 control-label">SMTP Username</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.STMPUsername" ng-model="settings.STMP.STMPUsername">
+                <span id="helpBlock" class="help-block">SMTP server username</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.STMPPassword" class="col-xs-4 col-sm-3 control-label">SMTP Password</label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="STMP.STMPPassword" ng-model="settings.STMP.STMPPassword">
+                <span id="helpBlock" class="help-block">SMTP server password</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="STMP.STMPSecure" class="col-xs-4 col-sm-3 control-label">Enable SSL/TLS</label>
+              <div class="col-xs-8 col-sm-9">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" name="STMP.STMPSecure" ng-model="settings.STMP.STMPSecure">
+                    Enable or disable SSL/TLS
+                  </label>
+                </div>
+              </div>
+            </div>
+
+
             <h5>Auth</h5>
             <div class="form-group">
             <fieldset disabled>
@@ -251,7 +320,7 @@
                 </select>
                 <span class="text-warning">Authentication methods are not yet implemented</span>
               </div>
-            </fieldset>  
+            </fieldset>
             </div>
             <div class="row">
             <label class="col-xs-4 col-sm-3 control-label">API Keys</label>
@@ -293,9 +362,9 @@
               </table>
               </div>
             </div>
-            
+
             <button type="submit" class="btn btn-default pull-right">Save</button>
-            
+
           </form>
         </div>
 </div>

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -197,19 +197,6 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="pushover.pushPriority" class="col-xs-4 col-sm-3 control-label">Priority</label>
-              <div class="col-xs-8 col-sm-9">
-                <select name="pushover.pushPriority" ng-model="settings.pushover.pushPriority" class="form-control">
-                  <option value="-2">Lowest Priority</option>
-                  <option value="-1">Low Priority</option>
-                  <option value="0">Normal Priority</option>
-                  <option value="1">High Priority</option>
-                  <option value="2">Emergency Priority</option>
-                </select>
-                <span id="helpBlock" class="help-block">Set's the priority messages will be sent at. More information can be found here <a href="https://pushover.net/api#priority">https://pushover.net/api#priority</a></span>
-              </div>
-            </div>
-            <div class="form-group">
               <label for="pushover.pushSound" class="col-xs-4 col-sm-3 control-label">Sound</label>
               <div class="col-xs-8 col-sm-9">
                 <select name="pushover.pushSound" ng-model="settings.pushover.pushSound" class="form-control">

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -659,7 +659,7 @@ router.post('/capcodes', function(req, res, next) {
         var Mailenable = req.body.mailenable || 0;
         var MailTo = req.body.mailto || 'null';
         db.serialize(() => {
-            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignorem, push, mailenable, mailto) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $MailEnable, $MailTo );", {
+            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignore, push, mailenable, mailto) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $MailEnable, $MailTo );", {
               $mesID: id,
               $mesAddress: address,
               $mesAlias: alias,


### PR DESCRIPTION
# Built in email support!

I have built in email support much like PDW.
New users need to make no DB changes, anyone updating from <=0.1.4 will need to run the following:

`ALTER TABLE capcodes ADD COLUMN mailenable INTEGER DEFAULT 0;`
`ALTER TABLE capcodes ADD COLUMN mailto TEXT;`
`ALTER TABLE capcodes ADD COLUMN pushpri TEXT;`

Supports SSL/TLS
Global on/off option in settings.
Per alias on/of
The TO address is set per alias and allow multiple recipients(Comma separated).

This update bumps the version to 0.1.5

Leverages the same query much like my pushover modification.
