### PR TITLE
Fix for Multimon-NG Square bracket encoding

### DIFF
--- a/client/reader.js
+++ b/client/reader.js
@@ -91,7 +91,7 @@ rl.on('line', (line) => {
   // if too much junk data, make sure '-p' option isn't enabled in multimon
   if (address.length > 4 && message) {
     var padAddress = padDigits(address,7);
-  	console.log(colors.red(time+': ')+colors.yellow(address+': ')+colors.success(trimMessage));
+  	console.log(colors.red(time+': ')+colors.yellow(padAddress+': ')+colors.success(trimMessage));
   	// now send the message
   	var options = {
   		method: 'POST',

--- a/client/reader.js
+++ b/client/reader.js
@@ -64,10 +64,10 @@ rl.on('line', (line) => {
   	address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
     if (line.indexOf('Alpha:') > -1) {
     	message = line.match(/Alpha:(.*?)$/)[1].trim();
-    	trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/[Ü]/g,']').replace(/[Ä]/g,'[');
+    	trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else if (line.indexOf('Numeric:') > -1) {
         message = line.match(/Numeric:(.*?)$/)[1].trim();
-        trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/[Ü]/g,']').replace(/[Ä]/g,'[');
+        trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else {
     	message = false;
     	trimMessage = '';

--- a/client/reader.js
+++ b/client/reader.js
@@ -64,10 +64,10 @@ rl.on('line', (line) => {
   	address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
     if (line.indexOf('Alpha:') > -1) {
     	message = line.match(/Alpha:(.*?)$/)[1].trim();
-    	trimMessage = message.replace(/<[A-Za-z]{3}>/g,'');
+    	trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/[Ü]/g,']').replace(/[Ä]/g,'[');
     } else if (line.indexOf('Numeric:') > -1) {
         message = line.match(/Numeric:(.*?)$/)[1].trim();
-        trimMessage = message.replace(/<[A-Za-z]{3}>/g,'');
+        trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/[Ü]/g,']').replace(/[Ä]/g,'[');
     } else {
     	message = false;
     	trimMessage = '';


### PR DESCRIPTION
Hi David,

Made some tweaks to the reader script to handle square brackets common in Victorian pager messages.
Multimon uses German charsets which spits out Ä and Ü characters instead of the brackets.

Looks like multimon-ng gave up on fixing this issue EliasOenal/multimon-ng#69

Also changed the console output to the padAddress just because the alignment was being messed up.

I don't really know much about node so these may cause issues in other places but i have been running this for a month with no issues.

Cheers
Dan

P.s - Sorry about the spam - realized i had missed a push with the correct code. 