### PR TITLE
Add Pushover Per Alias Settings. 

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,4 @@
-var version = "0.1.5-beta";
+var version = "0.1.6-beta";
 
 var debug = require('debug')('pagermon:server');
 var pmx = require('pmx').init({
@@ -43,6 +43,8 @@ var db = new sqlite3.Database('./messages.db', sqlite3.OPEN_READWRITE | sqlite3.
           sql += "color TEXT, ";
           sql += "push INTEGER DEFAULT 0, ";
           sql += "pushpri TEXT, ";
+          sql += "pushgroup TEXT, ";
+          sql += "pushsound TEXT, ";
           sql += "mailenable INTEGER DEFAULT 0, ";
           sql += "mailto TEXT, ";
           sql += "ignore INTEGER DEFAULT 0 ); ";

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -46,9 +46,7 @@
   },
   "pushover":{
     "pushenable": false,
-    "pushAPIKEY":  "",
-    "pushgroup":   "",
-    "pushSound": "pushover"
+    "pushAPIKEY":  ""
   },
   "STMP":{
     "MailEnable": false,

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -106,10 +106,10 @@
             </div>
 
             <div class="form-group">
-              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpeiants</label>
+              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpeients</label>
               <div class="col-xs-8 col-sm-9">
               <input class="form-control" type="text" name="alias.mailto" ng-model="alias.mailto">
-              <span id="helpBlock" class="help-block">Recpeiants for this capcode, comma separated</span>
+              <span id="helpBlock" class="help-block">Recpeients for this capcode, comma separated</span>
               </div>
             </div>
 
@@ -136,6 +136,45 @@
                   <option value="2">Emergency Priority</option>
                 </select>
                 <span id="helpBlock" class="help-block">Set's the priority messages will be sent at. More information can be found here <a href="https://pushover.net/api#priority">https://pushover.net/api#priority</a></span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="alias.pushgroup" class="col-xs-4 col-sm-3 control-label">Pushover - User/Group Key </label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="alias.pushgroup" ng-model="alias.pushgroup">
+                <span id="helpBlock" class="help-block">This can be a individual user key or a group key.</a>
+                </span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="alias.pushsound" class="col-xs-4 col-sm-3 control-label">Sound</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="alias.pushsound" ng-model="alias.pushsound" class="form-control">
+                  <option value=""></option>
+                  <option value="pushover">Pushover</option>
+                  <option value="bike">Bike</option>
+                  <option value="bugle">Bugle</option>
+                  <option value="cashregister">Cash Register</option>
+                  <option value="classical">Classical</option>
+                  <option value="cosmic">Cosmic</option>
+                  <option value="falling">Falling</option>
+                  <option value="gamelan">Gamelan</option>
+                  <option value="incoming">Incoming</option>
+                  <option value="intermission">Intermission</option>
+                  <option value="magic">Magic</option>
+                  <option value="mechanical">Mechanical</option>
+                  <option value="pianobar">Piano Bar</option>
+                  <option value="siren">Siren</option>
+                  <option value="spacealarm">Space Alarm</option>
+                  <option value="tugboat">Tug Boat</option>
+                  <option value="alien">Alien Alarm (long)</option>
+                  <option value="climb">Climb (long)</option>
+                  <option value="persistent">Persistent (long)</option>
+                  <option value="echo">Pushover Echo (long)</option>
+                  <option value="updown">Up Down (long)</option>
+                  <option value="none">None (silent)</option>
+                </select>
+                <span id="helpBlock" class="help-block">Sets the Notification Sound - Leaving this blank will use the default notification sound set in your application</span>
               </div>
             </div>
 

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -106,7 +106,7 @@
             </div>
 
             <div class="form-group">
-              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpeients</label>
+              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpients</label>
               <div class="col-xs-8 col-sm-9">
               <input class="form-control" type="text" name="alias.mailto" ng-model="alias.mailto">
               <span id="helpBlock" class="help-block">Recpeients for this capcode, comma separated</span>

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -106,10 +106,10 @@
             </div>
 
             <div class="form-group">
-              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recpients</label>
+              <label for="alias.mailto" class="col-xs-4 col-sm-3 control-label">SMTP Recipients</label>
               <div class="col-xs-8 col-sm-9">
               <input class="form-control" type="text" name="alias.mailto" ng-model="alias.mailto">
-              <span id="helpBlock" class="help-block">Recpeients for this capcode, comma separated</span>
+              <span id="helpBlock" class="help-block">Recipients for this capcode, comma separated</span>
               </div>
             </div>
 

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -189,43 +189,6 @@
                 <span id="helpBlock" class="help-block">Application key supplied by Pushover.</span>
               </div>
             </div>
-            <div class="form-group">
-              <label for="pushover.pushgroup" class="col-xs-4 col-sm-3 control-label">User/Group Key</label>
-              <div class="col-xs-8 col-sm-9">
-                <input type="text" class="form-control" name="pushover.pushgroup" ng-model="settings.pushover.pushgroup">
-                <span id="helpBlock" class="help-block">This can be a individual user key or a group key.</span>
-              </div>
-            </div>
-            <div class="form-group">
-              <label for="pushover.pushSound" class="col-xs-4 col-sm-3 control-label">Sound</label>
-              <div class="col-xs-8 col-sm-9">
-                <select name="pushover.pushSound" ng-model="settings.pushover.pushSound" class="form-control">
-                  <option value="pushover">Pushover (default)</option>
-                  <option value="bike">Bike</option>
-                  <option value="bugle">Bugle</option>
-                  <option value="cashregister">Cash Register</option>
-                  <option value="classical">Classical</option>
-                  <option value="cosmic">Cosmic</option>
-                  <option value="falling">Falling</option>
-                  <option value="gamelan">Gamelan</option>
-                  <option value="incoming">Incoming</option>
-                  <option value="intermission">Intermission</option>
-                  <option value="magic">Magic</option>
-                  <option value="mechanical">Mechanical</option>
-                  <option value="pianobar">Piano Bar</option>
-                  <option value="siren">Siren</option>
-                  <option value="spacealarm">Space Alarm</option>
-                  <option value="tugboat">Tug Boat</option>
-                  <option value="alien">Alien Alarm (long)</option>
-                  <option value="climb">Climb (long)</option>
-                  <option value="persistent">Persistent (long)</option>
-                  <option value="echo">Pushover Echo (long)</option>
-                  <option value="updown">Up Down (long)</option>
-                  <option value="none">None (silent)</option>
-                </select>
-                <span id="helpBlock" class="help-block">Sets the Application Sound</span>
-              </div>
-            </div>
 
 
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -367,7 +367,9 @@ router.get('/capcodes/:id', function(req, res, next) {
                         "agency": "",
                         "icon": "question",
                         "color": "black",
-                        "push" : "",
+                        "push": "",
+                        "pushgroup": "",
+                        "pushsound": "",
                         "pushpri": "0",
                         "mailenable" : "",
                         "mailto" : ""
@@ -401,7 +403,9 @@ router.get('/capcodeCheck/:id', function(req, res, next) {
                         "agency": "",
                         "icon": "question",
                         "color": "black",
-                        "push" : "",
+                        "push": "",
+                        "pushgroup": "",
+                        "pushsound": "",
                         "pushpri": "0",
                         "mailenable" : "",
                         "mailto" : ""
@@ -456,8 +460,6 @@ router.post('/messages', function(req, res, next) {
         var pdwMode = nconf.get('messages:pdwMode');
         var pushenable = nconf.get('pushover:pushenable');
         var pushkey = nconf.get('pushover:pushAPIKEY');
-        var pushgroup = nconf.get('pushover:pushgroup');
-        var pushSound = nconf.get('pushover:pushSound');
         var mailEnable = nconf.get('STMP:MailEnable');
         var MailFrom      = nconf.get('STMP:MailFrom');
         var MailFromName  = nconf.get('STMP:MailFromName');
@@ -484,11 +486,13 @@ router.post('/messages', function(req, res, next) {
                         res.status(200);
                         res.send('Ignoring duplicate');
                     } else {
-                        db.get("SELECT id, ignore, push, pushpri, mailenable, mailto FROM capcodes WHERE ? LIKE address ORDER BY REPLACE(address, '_', '%') DESC LIMIT 1", address, function(err,row) {
+                        db.get("SELECT id, ignore, push, pushpri, pushgroup, pushsound, mailenable, mailto FROM capcodes WHERE ? LIKE address ORDER BY REPLACE(address, '_', '%') DESC LIMIT 1", address, function(err,row) {
                             var insert;
                             var alias_id = null;
                             var pushonoff = null;
                             var pushpri = null;
+                            var pushgroup = null;
+                            var pushsound = null;
                             var mailonoff = null;
                             var mailTo = "";
                             if (err) { console.error(err) }
@@ -501,6 +505,8 @@ router.post('/messages', function(req, res, next) {
                                     alias_id = row.id;
                                     pushonoff = row.push;
                                     pushPri = row.pushpri;
+                                    pushGroup = row.pushgroup;
+                                    pushSound = row.pushsound;
                                     mailonoff = row.mailenable;
                                     mailTo = row.mailto;
                                 }
@@ -578,7 +584,7 @@ router.post('/messages', function(req, res, next) {
                                                     //check the alais to see if push is enabled for it
                                                     if (pushonoff == 1) {
                                                         var p = new push({
-                                                            user: pushgroup,
+                                                            user: pushGroup,
                                                             token: pushkey,
                                                         });
 
@@ -659,10 +665,12 @@ router.post('/capcodes', function(req, res, next) {
         var ignore = req.body.ignore || 0;
         var push = req.body.push || 0;
         var pushpri = req.body.pushpri || "0";
+        var pushgroup = req.body.pushgroup || 0;
+        var pushsound = req.body.pushsound || '';
         var Mailenable = req.body.mailenable || 0;
         var MailTo = req.body.mailto || '';
         db.serialize(() => {
-            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignore, push, pushpri, mailenable, mailto) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $mesPushPri, $MailEnable, $MailTo );", {
+            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignore, push, pushpri, pushgroup, pushsound, mailenable, mailto) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $mesPushPri, $mesPushGroup, $mesPushSound, $MailEnable, $MailTo );", {
               $mesID: id,
               $mesAddress: address,
               $mesAlias: alias,
@@ -671,7 +679,9 @@ router.post('/capcodes', function(req, res, next) {
               $mesIcon: icon,
               $mesIgnore: ignore,
               $mesPush : push,
-              $mesPushPri : pushpri,
+              $mesPushPri: pushpri,
+              $mesPushGroup: pushgroup,
+              $mesPushSound: pushsound,
               $MailEnable : Mailenable,
               $MailTo : MailTo
             }, function(err){
@@ -730,13 +740,15 @@ router.post('/capcodes/:id', function(req, res, next) {
         var ignore = req.body.ignore || 0;
         var push = req.body.push || 0;
         var pushpri = req.body.pushpri || "0";
+        var pushgroup = req.body.pushgroup || 0;
+        var pushsound = req.body.pushsound || '';  
         var Mailenable = req.body.mailenable || 0;
         var MailTo = req.body.mailto || '';
         var updateAlias = req.body.updateAlias || 0;
         console.time('insert');
         db.serialize(() => {
             //db.run("UPDATE tbl SET name = ? WHERE id = ?", [ "bar", 2 ]);
-            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignore, push, pushpri, mailenable, mailto  ) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $mesPushPri, $MailEnable, $MailTo );", {
+            db.run("REPLACE INTO capcodes (id, address, alias, agency, color, icon, ignore, push, pushpri, pushgroup, pushsound, mailenable, mailto  ) VALUES ($mesID, $mesAddress, $mesAlias, $mesAgency, $mesColor, $mesIcon, $mesIgnore, $mesPush, $mesPushPri, $mesPushGroup, $mesPushSound, $MailEnable, $MailTo );", {
               $mesID: id,
               $mesAddress: address,
               $mesAlias: alias,
@@ -745,7 +757,9 @@ router.post('/capcodes/:id', function(req, res, next) {
               $mesIcon: icon,
               $mesIgnore: ignore,
               $mesPush : push,
-              $mesPushPri : pushpri,
+              $mesPushPri: pushpri,
+              $mesPushGroup: pushgroup,
+              $mesPushSound: pushsound,
               $MailEnable : Mailenable,
               $MailTo : MailTo
             }, function(err){


### PR DESCRIPTION
Changed Pushover Notification Sound and User/Group keys to be per alias settings rather than global as suggested in https://github.com/davidmckenzie/pagermon/issues/85

This will require a database change unfortunately. Bumped the version number to 0.1.6 due to this. 

`ALTER TABLE capcodes ADD COLUMN pushgroup TEXT;
ALTER TABLE capcodes ADD COLUMN pushsound TEXT;`

Would like if you guys could review, as i hacked this together without really knowing what i'm doing - it seems to work though! 