### PR TITLE
Open Alias Edit screen in new tab/window

### DIFF
--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -441,9 +441,10 @@ var app = angular.module('app', ['ngRoute', 'ngResource', 'ngCookies', 'angular-
       };
       
       $scope.editAlias = function(alias){
-        // admin urls need to use $window since they don't use this route
-        $window.location.href = '/admin/aliases/'+alias;
-      };
+        // use window.open to launch a new tab when editing aliases
+        var editurl = '/admin/aliases/'+alias;
+          window.open(editurl, '_blank');
+       };
       
       $scope.clearSearch = function(){
         $scope.query = '';


### PR DESCRIPTION
Modifies the home page to open the New/Edit Alias screen in a new window as a workaround for https://github.com/davidmckenzie/pagermon/issues/47

This behavior probably isn't desirable for the filter clickables (Source/Agency/Capcode) as a majority of users would want to be filtering in the window they are in. 