### PR TITLE
Fix for Chrome Notifications

### DIFF
--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -571,9 +571,7 @@ function notify(notifyTitle,notifyMessage) {
     else if (Notification.permission === "granted") {
         var options = {
             body: notifyMessage,
-            icon: '/favicon.ico',
-            image: '/favicon.ico',
-            badge: '/favicon.ico'
+            icon: '/favicon.ico'
         };
         var notification = new Notification(notifyTitle,options);
     }
@@ -587,8 +585,6 @@ function notify(notifyTitle,notifyMessage) {
                 var options = {
                     body: notifyMessage,
                     icon: '/favicon.ico',
-                    image: '/favicon.ico',
-                    badge: '/favicon.ico'
                 };
                 var notification = new Notification(notifyTitle,options);
             }


### PR DESCRIPTION
Fix for chrome notifications being truncated with a huge logo
Example for broken notifications https://i.imgur.com/3kbtaaG.png
Example with these lines removed https://i.imgur.com/oWt1bCZ.png

Image in fixed is a custom favicon and not included in the commit 😄