### PR TITLE
Sec mode cleanup

### DIFF
--- a/client/samples/testMessage.sh
+++ b/client/samples/testMessage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cd .. && echo "POCSAG512: Address: 1000000  Function: 0  Alpha:   Test message, disregard<EOT>" | node ./reader.js
+cd .. && echo "POCSAG512: Address: 1000000  Function: 0  Alpha: `date` Test message, disregard<EOT>" | node ./reader.js


### PR DESCRIPTION
@marshyonline nothing personal... just had a different idea on how to solve 😁 

So this should fix up those errors with a little less dupe code - the only annoying thing here is that the GET routes won't work via API key auth. I couldn't find a neat way around that, as the passport.authenticate middleware just really didn't like being called from within other middleware. Would love a fix for that if anyone's more skilled with passport, but I'm assuming there isn't anyone using the API directly for GETting, and fewer still that would be using it with sec mode on.

We may be able to set the req.isAuthenticated flag via the API key auth, which would mean isLoggedIn works for all the routes, but that's something to look at another day.

Also added `date` to the test script cos it was really annoying me.