### PR TITLE
Cookie domains

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -50,6 +50,8 @@ var nconf = require('nconf');
     nconf.load();
 
 var port = normalizePort(process.env.PORT || '3000');
+var hostname = process.env.HOSTNAME;
+console.log(hostname);
 var app = express();
     app.set('port', port);
     // view engine setup
@@ -101,13 +103,17 @@ app.use(logger('combined'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
-app.use(session({
+var sessSet = {
     cookie: { maxAge: 7 * 24 * 60 * 60 * 1000 }, // 1 week
     store: new SQLiteStore,
     saveUninitialized: true,
     resave: 'true',
     secret: secret
-}));
+}
+if (hostname)
+    sessSet.cookie.domain = hostname;
+console.log(sessSet);
+app.use(session(sessSet));
 app.use(passport.initialize());
 app.use(passport.session()); // persistent login sessions
 app.use(flash());

--- a/server/app.js
+++ b/server/app.js
@@ -50,8 +50,6 @@ var nconf = require('nconf');
     nconf.load();
 
 var port = normalizePort(process.env.PORT || '3000');
-var hostname = process.env.HOSTNAME;
-console.log(hostname);
 var app = express();
     app.set('port', port);
     // view engine setup
@@ -103,6 +101,7 @@ app.use(logger('combined'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
+
 var sessSet = {
     cookie: { maxAge: 7 * 24 * 60 * 60 * 1000 }, // 1 week
     store: new SQLiteStore,
@@ -110,9 +109,10 @@ var sessSet = {
     resave: 'true',
     secret: secret
 }
+var hostname = process.env.HOSTNAME;
 if (hostname)
-    sessSet.cookie.domain = hostname;
-console.log(sessSet);
+    sessSet.cookie.domain = '.'+hostname;
+
 app.use(session(sessSet));
 app.use(passport.initialize());
 app.use(passport.session()); // persistent login sessions

--- a/server/process-default.json
+++ b/server/process-default.json
@@ -20,6 +20,7 @@
   "vizion"           : false, // enable/disable vizion features (versioning control)
   "env": {
     "NODE_ENV": "production",
+    "HOSTNAME": "",
     "APP_NAME": "pagermon"
   }
 }


### PR DESCRIPTION
Resolves #27

You guys might be interested in this - if you update your process.json file with a hostname, cookies should now support subdomains of that host, so sessions will persist across domains. I.e. if you login on localhost.localdomain, you will still be logged in on www.localhost.localdomain

See the new process-default.json for syntax.

Note that you do need to clear cookies before first use of this, as the browser will use the old domain by default if any cookies already exist.