### PR TITLE
Add time based duplicate filtering

### DIFF
--- a/server/config/default.json
+++ b/server/config/default.json
@@ -12,6 +12,7 @@
     "defaultLimit": 20,
     "duplicateFiltering": true,
     "duplicateLimit": 10,
+    "duplicateTime": 60,
     "rotationEnabled": true,
     "rotateDays": 7,
     "rotateKeep": 4,

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -105,14 +105,22 @@
                 <label>
                   <input type="checkbox" name="messages.duplicateFiltering" ng-model="settings.messages.duplicateFiltering"> Filter out duplicate messages
                 </label>
+                <span id="helpBlock" class="help-block">Limit filtering in one or both of the below fields.</span>
                 </div>
               </div>
             </div>
             <div class="form-group">
-              <label for="messages.duplicateLimit" class="col-xs-4 col-sm-3 control-label">Duplicate limit</label>
+              <label for="messages.duplicateLimit" class="col-xs-4 col-sm-3 control-label">Duplicate message limit</label>
               <div class="col-xs-8 col-sm-9">
               <input type="number" class="form-control" name="messages.duplicateLimit" ng-model="settings.messages.duplicateLimit" ng-disabled="!settings.messages.duplicateFiltering">
-              <span id="helpBlock" class="help-block">Ignore a message if one of the last {{settings.messages.duplicateLimit}} messages contains the same address and content.</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="messages.duplicateLimit" class="col-xs-4 col-sm-3 control-label">Duplicate time limit</label>
+              <div class="col-xs-8 col-sm-9">
+              <input type="number" class="form-control" name="messages.duplicateTime" ng-model="settings.messages.duplicateTime" ng-disabled="!settings.messages.duplicateFiltering">
+              <span id="helpBlock" class="help-block">Ignore a message if one of the last {{settings.messages.duplicateLimit}} messages in the past {{settings.messages.duplicateTime}} seconds contains the same address and content.
+                  <br />Set to 0 or blank to not limit the duplicate check query. This can impact database performance if both this and the above field are blank.</span>
               </div>
             </div>
             <div class="form-group">

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -563,6 +563,7 @@ router.post('/messages', function(req, res, next) {
       var datetime = req.body.datetime || 1;
       var timeDiff = datetime - dupeTime;
       var source = req.body.source || 'UNK';
+      
       var dupeCheck = 'SELECT * FROM messages WHERE ';
       if (dupeLimit != 0 || dupeTime != 0) {
         dupeCheck += 'id IN ( SELECT id FROM messages ';
@@ -576,9 +577,7 @@ router.post('/messages', function(req, res, next) {
       } else {
         dupeCheck += 'message LIKE "'+message+'" AND address="'+address+'";';
       }
-      // var dupeCheck = 'SELECT * FROM messages WHERE id IN ( SELECT id FROM messages WHERE timestamp > '+timeDiff+' ORDER BY id DESC LIMIT '+dupeLimit;
-      //     dupeCheck +=' ) AND message LIKE "'+message+'" AND address="'+address+'";';
-      console.log(dupeCheck);
+
       db.get(dupeCheck, [], function (err, row) {
         if (err) {
           res.status(500).send(err);


### PR DESCRIPTION
Resolves #40

Allows filtering of duplicate messages based on a time limit (e.g. past 60 seconds) as well as or instead of the current 'last x messages' filtering.