### PR TITLE
Add Discord Webhook Support and Twitter API Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The UI is built around a Node/Express/Angular/Bootstrap stack, while the client 
 * Push notifications
     * [Pushover](https://pushover.net/) Integration - near realtime muti-device notification service
     * [Telegram](https://telegram.org/) Integration - near realtime cloud based multi-device messaging
+    * [Discord](https://discordapp.com/) Integration - near realtime cloud based messaging service
     * Email Support for conventional SMTP email notifications 
 * May or may not contain cute puppies
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The UI is built around a Node/Express/Angular/Bootstrap stack, while the client 
     * [Pushover](https://pushover.net/) Integration - near realtime muti-device notification service
     * [Telegram](https://telegram.org/) Integration - near realtime cloud based multi-device messaging
     * [Discord](https://discordapp.com/) Integration - near realtime cloud based messaging service
+    * [Twitter](www.twitter.com) Integration 
     * Email Support for conventional SMTP email notifications 
 * May or may not contain cute puppies
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,5 @@
 var version = "0.1.9-beta";
-var release = 20181103;
+var release = 20181116;
 
 var debug = require('debug')('pagermon:server');
 var pmx = require('pmx').init({

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -64,6 +64,10 @@
     "twitaccsecret": "",
     "twitglobalhashtags": ""
   },
+  "discord":{
+    "discenable": false
+  
+  },
   "STMP":{
     "MailEnable": false,
     "MailFrom": "",

--- a/server/db.js
+++ b/server/db.js
@@ -21,8 +21,7 @@ function init(release) {
                 sql += "telegram INTEGER DEFAULT 0, ";
                 sql += "telechat TEXT, ";
                 sql += "discord INTEGER DEFAULT 0, ";
-                sql += "discwebhookid TEXT, ";
-                sql += "discwebhooktoken TEXT, ";
+                sql += "discwebhook TEXT, ";
                 sql += "ignore INTEGER DEFAULT 0 ); ";
                 // initialise messages table
                 sql += "CREATE TABLE IF NOT EXISTS messages ( ";
@@ -92,8 +91,7 @@ function init(release) {
                                     db.run("ALTER TABLE capcodes ADD telegram INTEGER DEFAULT 0", function(err){ /* ignore error */ });
                                     db.run("ALTER TABLE capcodes ADD telechat TEXT", function(err){ /* ignore error */ });
                                     db.run("ALTER TABLE capcodes ADD discord INTEGER DEFAULT 0", function (err) { /* ignore error */ });
-                                    db.run("ALTER TABLE capcodes ADD discwebhookid TEXT", function (err) { /* ignore error */ });
-                                    db.run("ALTER TABLE capcodes ADD discwebhooktoken TEXT", function (err) { /* ignore error */ });
+                                    db.run("ALTER TABLE capcodes ADD discwebhook TEXT", function (err) { /* ignore error */ });
                                     db.run("ALTER TABLE capcodes ADD ignore INTEGER DEFAULT 0", function (err) { /* ignore error */ });
                                     db.run("PRAGMA user_version = "+release, function(err){ /* ignore error */ });
                                 });

--- a/server/db.js
+++ b/server/db.js
@@ -20,6 +20,9 @@ function init(release) {
                 sql += "mailto TEXT, ";
                 sql += "telegram INTEGER DEFAULT 0, ";
                 sql += "telechat TEXT, ";
+                sql += "discord INTEGER DEFAULT 0, ";
+                sql += "discwebhookid TEXT, ";
+                sql += "discwebhooktoken TEXT, ";
                 sql += "ignore INTEGER DEFAULT 0 ); ";
                 // initialise messages table
                 sql += "CREATE TABLE IF NOT EXISTS messages ( ";
@@ -88,7 +91,10 @@ function init(release) {
                                     db.run("ALTER TABLE capcodes ADD mailenable INTEGER DEFAULT 0", function(err){ /* ignore error */ });
                                     db.run("ALTER TABLE capcodes ADD telegram INTEGER DEFAULT 0", function(err){ /* ignore error */ });
                                     db.run("ALTER TABLE capcodes ADD telechat TEXT", function(err){ /* ignore error */ });
-                                    db.run("ALTER TABLE capcodes ADD ignore INTEGER DEFAULT 0", function(err){ /* ignore error */ });
+                                    db.run("ALTER TABLE capcodes ADD discord INTEGER DEFAULT 0", function (err) { /* ignore error */ });
+                                    db.run("ALTER TABLE capcodes ADD discwebhookid TEXT", function (err) { /* ignore error */ });
+                                    db.run("ALTER TABLE capcodes ADD discwebhooktoken TEXT", function (err) { /* ignore error */ });
+                                    db.run("ALTER TABLE capcodes ADD ignore INTEGER DEFAULT 0", function (err) { /* ignore error */ });
                                     db.run("PRAGMA user_version = "+release, function(err){ /* ignore error */ });
                                 });
                             } else {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "cookie-parser": "~1.4.3",
     "core-js": "^2.4.1",
     "debug": "~2.6.3",
+    "discord.js": "latest",
     "ejs": "~2.5.6",
     "express": "~4.16.3",
     "express-basic-auth": "^1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "angularjs-color-picker": "^3.3.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.17.2",
+    "colornames": "latest",
     "compression": "^1.6.2",
     "connect-flash": "^0.1.1",
     "connect-sqlite3": "^0.9.9",

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -210,25 +210,16 @@
                     <input type="checkbox" name="alias.discord" ng-model="alias.discord" ng-true-value="1" ng-false-value="0">
                     Enable sending via Discord
                   </label>
-                  <span id="helpBlock" class="help-block">If checked, messages matching this alias will be sent via webhook to Discord</span>
+                  <span id="helpBlock" class="help-block">If checked, messages matching this alias will be sent via webhook to a Discord Channel</span>
                 </div>
               </div>
             </div>
-            <div class="form-group" ng-class="!alias.discwebhookid && alias.discord || alias.discwebhookid == 0 && alias.discord ? 'has-error' : 'has-success'">
-              <label for="alias.discwebhookid" class="col-xs-4 col-sm-3 control-label">Discord - Webhook URL </label>
+            <div class="form-group" ng-class="!alias.discwebhook && alias.discord || alias.discwebhook == 0 && alias.discord ? 'has-error' : 'has-success'">
+              <label for="alias.discwebhook" class="col-xs-4 col-sm-3 control-label">Discord - Webhook URL </label>
               <div class="col-xs-8 col-sm-9">
-                <input type="text" class="form-control" name="alias.discwebhookid" ng-model="alias.discwebhookid" ng-disabled="!alias.discord"
+                <input type="text" class="form-control" name="alias.discwebhook" ng-model="alias.discwebhook" ng-disabled="!alias.discord"
                   ng-required="alias.discord">
-                <span id="helpBlock" class="help-block">Discord Webhook ID</a>
-                </span>
-              </div>
-            </div>
-            <div class="form-group" ng-class="!alias.discwebhooktoken && alias.discord || alias.discwebhooktoken == 0 && alias.discord ? 'has-error' : 'has-success'">
-              <label for="alias.discwebhooktoken" class="col-xs-4 col-sm-3 control-label">Discord - Webhook Token </label>
-              <div class="col-xs-8 col-sm-9">
-                <input type="text" class="form-control" name="alias.discwebhooktoken" ng-model="alias.discwebhooktoken" ng-disabled="!alias.discord"
-                  ng-required="alias.discord">
-                <span id="helpBlock" class="help-block">Discord Webhook Token</a>
+                <span id="helpBlock" class="help-block">Provide the full Discord Webhook URL from your Server Settings page.</a>
                 </span>
               </div>
             </div>

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -200,7 +200,39 @@
                 </span>
               </div>
             </div>
-        
+            
+            <h5>Discord</h5>
+            <div class="form-group">
+              <label for="alias.discord" class="col-xs-4 col-sm-3 control-label">Discord</label>
+              <div class="col-xs-8 col-sm-9">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" name="alias.discord" ng-model="alias.discord" ng-true-value="1" ng-false-value="0">
+                    Enable sending via Discord
+                  </label>
+                  <span id="helpBlock" class="help-block">If checked, messages matching this alias will be sent via webhook to Discord</span>
+                </div>
+              </div>
+            </div>
+            <div class="form-group" ng-class="!alias.discwebhookid && alias.discord || alias.discwebhookid == 0 && alias.discord ? 'has-error' : 'has-success'">
+              <label for="alias.discwebhookid" class="col-xs-4 col-sm-3 control-label">Discord - Webhook URL </label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="alias.discwebhookid" ng-model="alias.discwebhookid" ng-disabled="!alias.discord"
+                  ng-required="alias.discord">
+                <span id="helpBlock" class="help-block">Discord Webhook ID</a>
+                </span>
+              </div>
+            </div>
+            <div class="form-group" ng-class="!alias.discwebhooktoken && alias.discord || alias.discwebhooktoken == 0 && alias.discord ? 'has-error' : 'has-success'">
+              <label for="alias.discwebhooktoken" class="col-xs-4 col-sm-3 control-label">Discord - Webhook Token </label>
+              <div class="col-xs-8 col-sm-9">
+                <input type="text" class="form-control" name="alias.discwebhooktoken" ng-model="alias.discwebhooktoken" ng-disabled="!alias.discord"
+                  ng-required="alias.discord">
+                <span id="helpBlock" class="help-block">Discord Webhook Token</a>
+                </span>
+              </div>
+            </div>
+
             <div class="btn-group pull-right" style="padding-right: 10px; padding-bottom: 10px;"role="group" aria-label="Actions">
               <button type="button" ng-if="!isNew" ng-click="aliasDelete()" class="btn btn-danger">Delete</button>
               <button type="button" ng-click="aliasLoad()" class="btn btn-default">Reset</button>

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -254,6 +254,20 @@
               </div>
             </div>
 
+            <h5>Discord</h5>
+            <div class="form-group">
+              <label for="discord.discenable" class="col-xs-4 col-sm-3 control-label">Enable</label>
+              <div class="col-xs-8 col-sm-9">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" name="discord.discenable" ng-model="settings.discord.discenable">
+                    Enable or disable for selected alias's
+                  </label>
+                </div>
+              </div>
+            </div>
+
+
 
             <h5>Email</h5>
             <div class="form-group">

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -214,7 +214,8 @@
               </div>
             </div>
 
-            <h5>Pushover</h5>
+            <h5>Notifications</h5>
+            <h6>Pushover</h6>
             <div class="form-group">
               <label for="pushover.pushenable" class="col-xs-4 col-sm-3 control-label">Enable</label>
               <div class="col-xs-8 col-sm-9">
@@ -234,7 +235,7 @@
               </div>
             </div>
 		  
-	    <h5>Telegram</h5>
+	    <h6>Telegram</h6>
             <div class="form-group">
               <label for="telegram.teleenable" class="col-xs-4 col-sm-3 control-label">Enable</label>
               <div class="col-xs-8 col-sm-9">
@@ -254,7 +255,7 @@
               </div>
             </div>
 
-            <h5>Discord</h5>
+            <h6>Discord</h6>
             <div class="form-group">
               <label for="discord.discenable" class="col-xs-4 col-sm-3 control-label">Enable</label>
               <div class="col-xs-8 col-sm-9">
@@ -269,7 +270,7 @@
 
 
 
-            <h5>Email</h5>
+            <h6>Email</h6>
             <div class="form-group">
               <label for="STMP.MailEnable" class="col-xs-4 col-sm-3 control-label">Enable</label>
               <div class="col-xs-8 col-sm-9">

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -791,7 +791,9 @@ router.post('/messages', function(req, res, next) {
                             
                             d.send(notificationText)
                               .then(console.log(`Discord: Message Sent`))
-                              .catch('Discord: ' + console.error);
+                              .catch(function (err) {
+                                'Discord: ' + console.error(err);
+                              });
                           }
                         };
                       }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -843,7 +843,7 @@ router.post('/messages', function(req, res, next) {
                             }
                             notificationembed.setColor(discordcolor);
                             notificationembed.setTitle(`**${row.agency} - ${row.alias}**`);
-                            notificationembed.addField('Message', `${row.message}`);
+                            notificationembed.setDescription(`${row.message}`);
                             if (hostname == undefined || !hostname) {
                               console.log('Discord: Hostname not set in config file using pagermon github')
                               notificationembed.setAuthor('PagerMon', '', `https://github.com/davidmckenzie/pagermon`);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -550,7 +550,7 @@ router.all('*',
     next();
   },
   function(err, req, res, next) {
-    console.debug('API key auth failed, attempting basic auth');
+    console.log('API key auth failed, attempting basic auth');
     isLoggedIn(req, res, next);
   }
 );
@@ -845,13 +845,13 @@ router.post('/messages', function(req, res, next) {
                             notificationembed.setTitle(`**${row.agency} - ${row.alias}**`);
                             notificationembed.addField('Message', `${row.message}`);
                             if (hostname == undefined || !hostname) {
-                              console.debug('Discord: Hostname not set in config file using pagermon github')
+                              console.log('Discord: Hostname not set in config file using pagermon github')
                               notificationembed.setAuthor('PagerMon', '', `https://github.com/davidmckenzie/pagermon`);
                             } else {
                               notificationembed.setAuthor('PagerMon', '', `${hostname}`);
                             }
                             //Print notification template when debugging enabled
-                            console.debug(notificationembed)
+                            console.log(notificationembed)
                             d.send(notificationembed)
                               .then(console.log(`Discord: Message Sent`))
                               .catch(function(err) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -786,12 +786,12 @@ router.post('/messages', function(req, res, next) {
                             var d = new discord.WebhookClient(discwebhookid, discwebhooktoken);
             
                             //Notification formatted in Markdown for pretty notifications
-                            var notificationText = `*${row.agency} - ${row.alias}*\n` +
-                              `Message: ${row.message}`;
+                            var notificationText = `***${row.agency} - ${row.alias}***\n` +
+                              `Message: **${row.message}**`;
                             
                             d.send(notificationText)
                               .then(console.log(`Discord: Message Sent`))
-                              .catch(function (err) {
+                              .catch(function(err) {
                                 'Discord: ' + console.error(err);
                               });
                           }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -784,7 +784,7 @@ router.post('/messages', function(req, res, next) {
                             var webhook = discwebhook.split('/');
                             var discwebhookid = webhook[5];
                             var discwebhooktoken = webhook[6];
-                            console.debug(discwebhookid + ' ' + discwebhooktoken)
+
                             var d = new discord.WebhookClient(discwebhookid, discwebhooktoken);
             
                             //Use embedded discord notification format from discord.js 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -779,6 +779,7 @@ router.post('/messages', function(req, res, next) {
                           }
                         };
                         if (discenable == true && disconoff == 1) {
+                          var toHex = require('colornames')
                           var hostname = nconf.get('hostname');
                           //Ensure webhook ID and Token have been entered into the alias. 
                           if ((discwebhookid == 0 || !discwebhookid) || (discwebhooktoken == 0 || !discwebhooktoken)) {
@@ -790,7 +791,14 @@ router.post('/messages', function(req, res, next) {
                             var notificationembed = new discord.RichEmbed({
                               timestamp: new Date(),
                             });
-                            notificationembed.setColor(`${row.color}`);
+                            // toHex doesn't support putting HEX in, needs to check and skip over if already hex. 
+                            var isHex = /^#[0-9A-F]{6}$/i.test(row.color)
+                            if (!isHex || isHex == false) {
+                              var discordcolor = toHex(row.color)
+                            } else {
+                              var discordcolor = row.color
+                            }
+                            notificationembed.setColor(discordcolor);
                             notificationembed.setTitle(`**${row.agency} - ${row.alias}**`);
                             notificationembed.addField('Message', `${row.message}`);
                             if (hostname == undefined || !hostname) {
@@ -799,7 +807,8 @@ router.post('/messages', function(req, res, next) {
                             } else {
                               notificationembed.setAuthor('PagerMon', '', `${hostname}`);
                             }
-                            
+                            //Print notification template when debugging enabled
+                            console.debug(notificationembed)
                             d.send(notificationembed)
                               .then(console.log(`Discord: Message Sent`))
                               .catch(function(err) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -779,17 +779,28 @@ router.post('/messages', function(req, res, next) {
                           }
                         };
                         if (discenable == true && disconoff == 1) {
-                          //ensure chatid has been entered before trying to push
+                          var hostname = nconf.get('hostname');
+                          //Ensure webhook ID and Token have been entered into the alias. 
                           if ((discwebhookid == 0 || !discwebhookid) || (discwebhooktoken == 0 || !discwebhooktoken)) {
                             console.error('Discord: ' + address + ' No Webhook URL set. Please enter Webhook URL.');
                           } else {
                             var d = new discord.WebhookClient(discwebhookid, discwebhooktoken);
             
-                            //Notification formatted in Markdown for pretty notifications
-                            var notificationText = `***${row.agency} - ${row.alias}***\n` +
-                              `Message: **${row.message}**`;
+                            //Use embedded discord notification format from discord.js 
+                            var notificationembed = new discord.RichEmbed({
+                              timestamp: new Date(),
+                            });
+                            notificationembed.setColor(`${row.color}`);
+                            notificationembed.setTitle(`**${row.agency} - ${row.alias}**`);
+                            notificationembed.addField('Message', `${row.message}`);
+                            if (hostname == undefined || !hostname) {
+                              console.debug('Discord: Hostname not set in config file using pagermon github')
+                              notificationembed.setAuthor('PagerMon', '', `https://github.com/davidmckenzie/pagermon`);
+                            } else {
+                              notificationembed.setAuthor('PagerMon', '', `${hostname}`);
+                            }
                             
-                            d.send(notificationText)
+                            d.send(notificationembed)
                               .then(console.log(`Discord: Message Sent`))
                               .catch(function(err) {
                                 'Discord: ' + console.error(err);


### PR DESCRIPTION
Add's support for posting messages directly to a Discord chat channel via Discord Webhook. 
![image](https://user-images.githubusercontent.com/26653344/48528040-5f5cc100-e8e1-11e8-9a33-e77b61c5911e.png)

Add's the ability to post pager messages to Twitter.
Requires a twitter developer account.

Allows for custom hashtags at the server and alias level.
![image](https://user-images.githubusercontent.com/26653344/48527960-0db43680-e8e1-11e8-8c42-e1de2215af76.png)
