### PR TITLE
Flex frag + retries

### DIFF
--- a/client/reader.js
+++ b/client/reader.js
@@ -63,16 +63,16 @@ rl.on('line', (line) => {
   // TODO: pad address with zeros for better address matching
 //  if (line.indexOf('POCSAG512: Address:') > -1) {	
   if (/^POCSAG(\d+): Address: /.test(line) ) {
-  	address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
+    address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
     if (line.indexOf('Alpha:') > -1) {
-    	message = line.match(/Alpha:(.*?)$/)[1].trim();
-    	trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
+      message = line.match(/Alpha:(.*?)$/)[1].trim();
+      trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else if (line.indexOf('Numeric:') > -1) {
       message = line.match(/Numeric:(.*?)$/)[1].trim();
       trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else {
-    	message = false;
-    	trimMessage = '';
+      message = false;
+      trimMessage = '';
     }
   } else if (line.indexOf('FLEX: ') > -1) {
     address = line.match(/FLEX:.*?\[(\d*?)\] /)[1].trim();
@@ -106,31 +106,31 @@ rl.on('line', (line) => {
   // if too much junk data, make sure '-p' option isn't enabled in multimon
   if (address.length > 2 && message) {
     var padAddress = padDigits(address,7);
-  	console.log(colors.red(time+': ')+colors.yellow(padAddress+': ')+colors.success(trimMessage));
-  	// now send the message
-  	var options = {
-  		method: 'POST',
-  		uri: uri,
-  		headers: {
-  			'X-Requested-With': 'XMLHttpRequest',
-  			apikey: apikey
-  		},
-  		form: {
-  			address: padAddress,
-  			message: trimMessage,
-  			datetime: datetime,
-  			source: identifier
-  		}
-  	};
-  	rp(options)
-  	    .then(function (body) {
-  	    //    console.log(colors.success('Message delivered. ID: '+body)); 
-  	    })
-  	    .catch(function (err) {
-  	        console.log(colors.yellow('Message failed to deliver. '+err));
-  	    });
+    console.log(colors.red(time+': ')+colors.yellow(padAddress+': ')+colors.success(trimMessage));
+    // now send the message
+    var options = {
+      method: 'POST',
+      uri: uri,
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        apikey: apikey
+      },
+      form: {
+        address: padAddress,
+        message: trimMessage,
+        datetime: datetime,
+        source: identifier
+      }
+    };
+    rp(options)
+        .then(function (body) {
+        //    console.log(colors.success('Message delivered. ID: '+body)); 
+        })
+        .catch(function (err) {
+            console.log(colors.yellow('Message failed to deliver. '+err));
+        });
   } else {
-  	console.log(colors.red(time+': ')+colors.grey(line));
+    console.log(colors.red(time+': ')+colors.grey(line));
   }
   
 }).on('close', () => {

--- a/client/reader.js
+++ b/client/reader.js
@@ -130,6 +130,7 @@ var sendPage = function(message,retries) {
     uri: uri,
     headers: {
       'X-Requested-With': 'XMLHttpRequest',
+      'User-Agent': 'PagerMon reader.js',
       apikey: apikey
     },
     form: message

--- a/client/reader.js
+++ b/client/reader.js
@@ -51,7 +51,7 @@ const rl = readline.createInterface({
     terminal: true
 });
 
-var frag;
+var frag = {};
 
 rl.on('line', (line) => {
   //console.log(`Received: ${line.trim()}`);
@@ -79,13 +79,14 @@ rl.on('line', (line) => {
     if (line.match( /( ALN | GPN | NUM)/ )) {
       if (line.match( / [0-9]{4}\/[0-9]\/F\/. / )) {
         // message is fragmented, hold onto it for next line
-        frag = line.match(/FLEX:.*?\[\d*\] ... (.*?)$/)[1].trim();
+        frag[address] = line.match(/FLEX:.*?\[\d*\] ... (.*?)$/)[1].trim();
         message = false;
         trimMessage = '';
       } else if (line.match( / [0-9]{4}\/[0-9]\/C\/. / )) {
         // message is a completion of the last fragmented message
         message = line.match(/FLEX:.*?\[\d*\] ... (.*?)$/)[1].trim();
-        trimMessage = frag+message;
+        trimMessage = frag[address]+message;
+        delete frag[address];
       } else if (line.match( / [0-9]{4}\/[0-9]\/K\/. / )) {
         // message is a full message
         message = line.match(/FLEX:.*?\[\d*\] ... (.*?)$/)[1].trim();


### PR DESCRIPTION
Resolves #108 and #76 

/cc @Shaggs and @112bzo as FLEX users

This moves the FLEX fragmented messages into an object with the address as key - fragmented messages that arrive with other messages in between should now properly join. The only real edge case I can think of is if in poor reception and you receive an F message, but never its corresponding C message, then you might one day receive a randomly joined message. Would be rare enough not to worry about, IMO.

The other change in this is the retries that @s3m1s0n1c requested - messages will retry sending on failure up to 10 times, with the time between retries increasing exponentially (`Math.pow(2, retries)`). This isn't the best way to handle this, especially for machines that will be offline for some time. The alternative would be to use a proper queuing system like Redis, but that would greatly increase the barrier to entry and reduce compatibility/portability. Probably something to look at if there was ever a demand for a "production ready" pagermon.