### PR TITLE
make hostname thing optional

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -109,9 +109,9 @@ var sessSet = {
     resave: 'true',
     secret: secret
 }
-var hostname = process.env.HOSTNAME;
-if (hostname)
-    sessSet.cookie.domain = '.'+hostname;
+
+if (process.env.HOSTNAME && process.env.USE_COOKIE_HOST)
+    sessSet.cookie.domain = '.'+process.env.HOSTNAME;
 
 app.use(session(sessSet));
 app.use(passport.initialize());

--- a/server/process-default.json
+++ b/server/process-default.json
@@ -20,6 +20,7 @@
   "env": {
     "NODE_ENV": "production",
     "HOSTNAME": "",
+    "USE_COOKIE_HOST": false,
     "APP_NAME": "pagermon"
   }
 }


### PR DESCRIPTION
Should resolve #158 - doesn't even attempt to set the cookie domain unless explicitly true'd in a new env variable