### PR TITLE
Add option to map function codes to a string in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix non matching messages when filtering alias #543 @geelongmicrosoldering
 * Fix [ERR_HTTP_HEADERS_SENT] error in /api route by combining res.status and res.send @nic-hanna
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
+* Add option to map function codes to a string in client #585 @ChoffaH
 
 # 0.3.13 - 2023-09-04
 * Add Config option to fix FA icon's no longer loading. @marshyonline

--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,7 @@ cp config/default.json config/config.json
 
 Edit config/config.json to suit your environment. Identifier should be a small string that will show up in the 'source' column of the messages display.
 
-Some environments send additional information via the "Function Code" in the pager message. Change `sendFunctionCode` to `true` to send this appended to the end of the address of each message. E.g. `POCSAG512: Address: 1000022  Function: 3  Alpha: test` would land on the server with an address of `10000223`.
+Some environments send additional information via the "Function Code" in the pager message. Change `sendFunctionCode` to `true` to send this appended to the end of the address of each message. E.g. `POCSAG512: Address: 1000022  Function: 3  Alpha: test` would land on the server with an address of `10000223`. Optionally you can setup a `functionCodeMap` to replace function codes with a string. E.g. with `functionCodeMap` set to `{ "3": "C" }` the previous address would land on the server with an address of `1000022C`
 
 Some environments prepend pager messages with a timestamp - by default reader.js will trim these from the message and use them as the timestamp for the message. If you do not wish for this to happen, set `useTimestamp` to `false`. Only a limited type of timestamps are currently supported - if you wish to add a time format, submit an issue with some example messages.
 

--- a/client/reader.js
+++ b/client/reader.js
@@ -30,6 +30,7 @@ var hostname = nconf.get('hostname');
 var apikey = nconf.get('apikey');
 var identifier = nconf.get('identifier');
 var sendFunctionCode = nconf.get('sendFunctionCode') || false;
+var functionCodeMap = nconf.get('functionCodeMap') || {};
 var useTimestamp = nconf.get('useTimestamp') || true;
 var EASOpts = nconf.get('EAS'); // Import EAS Config Object Ref Pull 435
 
@@ -75,7 +76,12 @@ rl.on('line', (line) => {
     if (/POCSAG(\d+): Address: /.test(line)) {
         address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
         if (sendFunctionCode) {
-            address += line.match(/POCSAG(\d+): Address:(.*?)Function: (\d)/)[3];
+            var functionCode = line.match(/POCSAG(\d+): Address:(.*?)Function: (\d)/)[3];
+            if (functionCodeMap && functionCodeMap[functionCode]) {
+                address += functionCodeMap[functionCode];
+            } else {
+                address += functionCode;
+            }
         }
         if (line.indexOf('Alpha:') > -1) {
             message = line.match(/Alpha:(.*?)$/)[1].trim();


### PR DESCRIPTION
# Description

Add option to setup `functionCodeMap` to replace function codes with a string. For example I want to replace 0 with A, 1 with B and so on. This enables me to do so with the following config: 

```
"functionCodeMap": {
    "0": "A",
    "1": "B",
    "2": "C",
    "3": "D"
},
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested this locally on my server for a couple of weeks.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



