### PR TITLE
Fix telegram markdown error

### DIFF
--- a/server/plugins/Telegram.js
+++ b/server/plugins/Telegram.js
@@ -14,13 +14,13 @@ function run(trigger, scope, data, config, callback) {
             callback();
         } else {
             //Notification formatted in Markdown for pretty notifications
-            var notificationText = `*${data.agency} - ${data.alias}*\n` + 
-                                    `Message: ${data.message}`;
+            var notificationText = `<b>${escapeTelegramHTML(data.agency)} - ${escapeTelegramHTML(data.alias)}</b>\n` + 
+                                    `Message: ${escapeTelegramHTML(data.message)}`;
             
             t.sendMessage({
                 chat_id: tConf.chat,
                 text: notificationText,
-                parse_mode: "Markdown"
+                parse_mode: "HTML"
             }).then(function(data) {
                 logger.main.debug('Telegram: ' + util.inspect(data, false, null));
                 callback();
@@ -32,6 +32,10 @@ function run(trigger, scope, data, config, callback) {
     } else {
         callback();
     }
+}
+
+function escapeTelegramHTML (string) {
+    return string.replace(/</,'&lt;').replace(/>/,'&gt;'.replace(/&/,'&amp;'));
 }
 
 module.exports = {


### PR DESCRIPTION
# Description
The Telegram API errors, if there is an uneven amount of markdown characters.
I switched the Formatter to HTML, because Messages are more likely to include markdown characters than valid HTML and escaping HTML should be easier. I also implemented escaping everything that could define HTML tags, so even if there are <, > or & chars, the telegram API should be happy

Breaking: If someone willingly changed the Telegram message format to use more markdown or does use the replace plugin to insert markdown into messages, this change will break their wanted behavior and display the markdown chars as plain text.

Fixes #610 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Not at all yet

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



