### PR TITLE
MySQL authentication support upgraded to the latest auth method (but backwards compatible)

### DIFF
--- a/client/reader.sh
+++ b/client/reader.sh
@@ -20,6 +20,7 @@
 ######################################################################
 # node reader.js : the cool thing that makes magic happen
 ######################################################################
-rtl_fm -d 0101 -E dc -F 0 -l 15 -A fast -f 148.5875M -s22050 - | 
-multimon-ng -q -b1 -c -a POCSAG512 -f alpha -t raw /dev/stdin | 
+#rtl_fm -d 0 -f 169.65M -M fm -s 22050 -p 0 - | 
+rtl_fm -d 0 -E dc -F 0 -A fast -f 169.650M -s22050 -M fm - |
+multimon-ng -a FLEX -t raw /dev/stdin | 
 node reader.js

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -15,6 +15,7 @@
     "type": "sqlite3",
     "aliasRefreshInterval": "0 5,35 * * * *",
     "auth_method": "default",
+    "auth_method_comment": "Supported values: default, mysql_native_password, sha256_password, caching_sha2_password",
     "server": "",
     "port": 3306,
     "username": "",

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -13,7 +13,14 @@
   "database": {
     "file": "./messages.db",
     "type": "sqlite3",
-    "aliasRefreshInterval": "0 5,35 * * * *"
+    "aliasRefreshInterval": "0 5,35 * * * *",
+    "auth_method": "default",
+    "server": "",
+    "port": 3306,
+    "username": "",
+    "password": "",
+    "database": "",
+    "ssl": false
   },
   "messages": {
     "maxLimit": 120,

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -44,11 +44,29 @@ if(process.env.NODE_ENV === 'test') {
 }else if (dbtype == 'sqlite3') {
   dbconfig.connection.filename = nconf.get('database:file');
 } else if (dbtype == 'mysql') {
+  dbconfig.client = 'mysql2';
   dbconfig.connection.host = nconf.get('database:server');
   dbconfig.connection.port = nconf.get('database:port');
   dbconfig.connection.user = nconf.get('database:username');
   dbconfig.connection.password = nconf.get('database:password');
   dbconfig.connection.database = nconf.get('database:database');
+  
+  // Support both authentication methods
+  const authMethod = nconf.get('database:auth_method') || 'default';
+  if (authMethod === 'mysql_native_password') {
+    dbconfig.connection.authPlugins = {
+      mysql_native_password: () => () => {
+        return require('mysql2/lib/auth_plugins/mysql_native_password');
+      }
+    };
+  }
+  
+  // Add support for SSL if configured
+  if (nconf.get('database:ssl')) {
+    dbconfig.connection.ssl = {
+      rejectUnauthorized: true
+    };
+  }
 } else if (dbtype == 'oracledb') {
   dbconfig.connection.connectString = nconf.get('database:connectString');
   dbconfig.connection.user = nconf.get('database:username');

--- a/server/package.json
+++ b/server/package.json
@@ -44,7 +44,7 @@
     "mocha": "^7.2.0",
     "moment": "^2.26.0",
     "morgan": "~1.9.1",
-    "mysql": "^2.16.0",
+    "mysql2": "^3.9.2",
     "nconf": "^0.8.4",
     "node-prowl": "latest",
     "node-uuid": "^1.4.8",

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -174,6 +174,16 @@
                 </div>
             </div> 
             <div class="form-group" ng-if="settings.database.type == 'mysql'">
+              <label for="database.auth_method" class="col-xs-4 col-sm-3 control-label">Authentication Method</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="database.auth_method" ng-model="settings.database.auth_method" class="form-control">
+                  <option value="default">Default (SHA2 Caching)</option>
+                  <option value="mysql_native_password">MySQL Native Password</option>
+                </select>
+                <span id="helpBlock" class="help-block">Select the MySQL authentication method. Use 'MySQL Native Password' for older MySQL servers or if you encounter authentication issues.</span>
+              </div>
+            </div>
+            <div class="form-group" ng-if="settings.database.type == 'mysql'">
               <label for="database.aliasRefreshInterval" class="col-xs-4 col-sm-3 control-label">Alias Refresh CRON</label>
               <div class="col-xs-8 col-sm-9">
               <input type="text" class="form-control" name="database.aliasRefreshInterval" ng-model="settings.database.aliasRefreshInterval">

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -179,6 +179,7 @@
                 <select name="database.auth_method" ng-model="settings.database.auth_method" class="form-control">
                   <option value="default">Default (SHA2 Caching)</option>
                   <option value="mysql_native_password">MySQL Native Password</option>
+                  <option value="sha256_password">SHA256 Password</option>
                 </select>
                 <span id="helpBlock" class="help-block">Select the MySQL authentication method. Use 'MySQL Native Password' for older MySQL servers or if you encounter authentication issues.</span>
               </div>


### PR DESCRIPTION
# Description

MySQL authentication support upgraded to the latest auth method. You can now choose an authentication method from a drop down menu when you select MySQL/MariaDB as a database target. This allows for backwards compatibility as well as future support for MySQL version > 8.0.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I installed a fresh Raspberry Pi and git cloned the repository with the new feature. Then I connected the pagermon server to a new MySQL server (version 9.1.0), with the SHA2 caching option. Next I connected to a old MySQL server which supported the native_mysql_password, this also went well. Both databases could be connected and user.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



