### PR TITLE
Feature: Hide all messages from a certain capcode

### DIFF
--- a/server/knex/migrations/20250410211537_update_capcodes_hideMessages.js
+++ b/server/knex/migrations/20250410211537_update_capcodes_hideMessages.js
@@ -1,0 +1,72 @@
+const nconf = require('nconf');
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ * */
+
+/**
+ * SQLITE does not allow tables to be renamed, if a trigger has a foreign key relation to them.
+ * Therefore, we have to temporarily delete the triggers and re-install them after doing the migration.
+ */
+
+const up = async function(knex) {
+        const isSqLite = nconf.get('database:type') === 'sqlite3';
+        let triggers;
+        if (isSqLite) {
+                triggers = await knex
+                        .from('sqlite_master')
+                        .select(['name', 'sql'])
+                        .where('type', 'trigger');
+
+                const promises = triggers.map(trigger => knex.raw(`DROP TRIGGER ${trigger.name}`));
+
+                await Promise.all(promises);
+        }
+        if (!(await knex.schema.hasTable('capcodes')))
+                return Promise((resolve, reject) => {
+                        reject('Capcode table is missing!');
+                });
+
+        await knex.schema.alterTable('capcodes', table => {
+                table.boolean('hideMessages').defaultTo(false);
+        });
+
+        await knex('capcodes').update({ onlyShowLoggedIn: false });
+
+        if (isSqLite) {
+                const promises = triggers.map(trigger => knex.raw(trigger.sql));
+                await Promise.all(promises);
+        }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function(knex) {
+        const isSqLite = nconf.get('database:type') === 'sqlite3';
+        let triggers;
+        if (isSqLite) {
+                triggers = await knex
+                        .from('sqlite_master')
+                        .select(['name', 'sql'])
+                        .where('type', 'trigger');
+
+                const promises = triggers.map(trigger => knex.raw(`DROP TRIGGER ${trigger.name}`));
+
+                await Promise.all(promises);
+        }
+
+        await knex.schema.alterTable('capcodes', table => {
+                table.dropColumn('hideMessages');
+        });
+
+        if (isSqLite) {
+                const promises = triggers.map(trigger => knex.raw(trigger.sql));
+                await Promise.all(promises);
+        }
+};
+
+module.exports.up = up;
+module.exports.down = down;

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -11,6 +11,7 @@ exports.seed = function(db, Promise) {
                                 icon: 'fire',
                                 color: 'red',
                                 ignore: '0',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: false,
                         })
                 )
@@ -22,6 +23,7 @@ exports.seed = function(db, Promise) {
                                 icon: 'ambulance',
                                 color: 'green',
                                 ignore: '0',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: false,
                         })
                 )
@@ -33,6 +35,7 @@ exports.seed = function(db, Promise) {
                                 icon: 'gavel',
                                 color: 'blue',
                                 ignore: '0',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: false,
                         })
                 )
@@ -44,6 +47,7 @@ exports.seed = function(db, Promise) {
                                 icon: '',
                                 color: '',
                                 ignore: '1',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: false,
                         })
                 )
@@ -55,18 +59,32 @@ exports.seed = function(db, Promise) {
                                 icon: '',
                                 color: '',
                                 ignore: '0',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: false,
                         })
                 )
                 .then(() =>
                         db('capcodes').insert({
                                 address: '1234571',
-                                alias: 'Hidden Capcode',
-                                agency: 'HIDE',
+                                alias: 'Capcode hidden to not logged in',
+                                agency: 'HIDEANON',
                                 icon: '',
                                 color: '',
                                 ignore: '0',
+                                hideMessages: '0',
                                 onlyShowLoggedIn: true,
+                        })
+                )
+                .then(() =>
+                        db('capcodes').insert({
+                                address: '1234572',
+                                alias: 'Capcode hidden to all users',
+                                agency: 'HIDEALL',
+                                icon: '',
+                                color: '',
+                                ignore: '0',
+                                hideMessages: '1',
+                                onlyShowLoggedIn: false,
                         })
                 )
                 .then(() =>
@@ -117,8 +135,8 @@ exports.seed = function(db, Promise) {
                 )
                 .then(() =>
                         db('messages').insert({
-                                address: '1234572',
-                                message: 'This is a Test Message to non-stored Address 1234572',
+                                address: '1234573',
+                                message: 'This is a Test Message to non-stored Address 1234573',
                                 source: 'Client 5',
                                 timestamp: '1529494322',
                                 alias_id: undefined,
@@ -132,6 +150,16 @@ exports.seed = function(db, Promise) {
                                 source: 'Client 4',
                                 timestamp: '1529494321',
                                 alias_id: 6,
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234572',
+                                message:
+                                        'This is a Test Message to Address 1234572, that should be hidden to all users',
+                                source: 'Client 4',
+                                timestamp: '1529494321',
+                                alias_id: 7,
                         })
                 )
                 .then(() => db('users').del())

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -73,25 +73,17 @@ router.route('/messages')
     } else {
       initData.limit = parseInt(defaultLimit, 10);
     }
-    if (pdwMode) {
-      if (adminShow && req.isAuthenticated() && req.user.role == 'admin') {
-        var subquery = db.from('capcodes').where('ignore', '=', 1).select('id')
-      } else {
-        var subquery = db.from('capcodes').where('ignore', '=', 0).select('id')
-      }
-    } else {
-      var subquery = db.from('capcodes').where('ignore', '=', 1).select('id')
-    }
+
     db.from('messages').where(function () {
       if( !req.isAuthenticated) this.where('capcodes.onlyShowLoggedIn',false);
       if (pdwMode) {
         if (adminShow && req.isAuthenticated() && req.user.role == 'admin') {
-          this.from('messages').where('alias_id', 'not in', subquery).orWhereNull('alias_id')
+          this.from('messages').where('alias_id', 'not in', db.from('capcodes').where('ignore', '=', 1).orWhere('hideMessages', 1).select('id')).orWhereNull('alias_id')
         } else {
-          this.from('messages').where('alias_id', 'in', subquery)
+          this.from('messages').where('alias_id', 'in', db.from('capcodes').where('ignore', '=', 0).andWhere('hideMessages',0).select('id'))
         }
       } else {
-        this.from('messages').where('alias_id', 'not in', subquery).orWhereNull('alias_id')
+        this.from('messages').where('alias_id', 'not in', db.from('capcodes').where('ignore', '=', 1).orWhere('hideMessages',1).select('id')).orWhereNull('alias_id')
       }
     }).count('* as msgcount')
       .then(function (initcount) {
@@ -119,12 +111,12 @@ router.route('/messages')
               if (!req.isAuthenticated()) queryBuilder.where('capcodes.onlyShowLoggedIn',false);
               if (pdwMode) {
                 if (adminShow && req.isAuthenticated() && req.user.role == 'admin') {
-                  queryBuilder.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where('capcodes.ignore', 0).orWhereNull('capcodes.ignore')
+                  queryBuilder.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where(qb => qb.where('capcodes.ignore', 0).orWhereNull('capcodes.ignore')).andWhere(qb => qb.where('capcodes.hideMessages', 0).orWhereNull('capcodes.hideMessages', 0))
                 } else {
-                  queryBuilder.innerJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where('capcodes.ignore', 0)
+                  queryBuilder.innerJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where('capcodes.ignore', 0).andWhere('capcodes.hideMessages', 0)
                 }
               } else {
-                queryBuilder.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where('capcodes.ignore', 0).orWhereNull('capcodes.ignore')
+                queryBuilder.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id').where(qb => qb.where('capcodes.ignore', 0).orWhereNull('capcodes.ignore')).andWhere(qb => qb.where('capcodes.hideMessages', 0).orWhereNull('capcodes.hideMessages', 0))
               }
             })
             .orderBy('messages.timestamp', 'desc')
@@ -456,6 +448,7 @@ router.route('/messages')
       )
       .leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id')
       .where('messages.id', id)
+      .where(qb => qb.where('capcodes.hideMessages', 0).orWhereNull('capcodes.hideMessages'))
       .modify((qb) => {
         if (!req.isAuthenticated()) qb.where('capcodes.onlyShowLoggedIn', false);
       })
@@ -465,24 +458,20 @@ router.route('/messages')
         }
 
         let responseData;
-        if (HideCapcode) {
-          if (!req.isAuthenticated() || (req.isAuthenticated() && req.user.role === 'user')) {
-            responseData = {
-              id: row[0].id,
-              message: row[0].message,
-              source: row[0].source,
-              datetime: row[0].timestamp,
-              timestamp: row[0].timestamp,
-              alias_id: row[0].alias_id,
-              alias: row[0].alias,
-              agency: row[0].agency,
-              icon: row[0].icon,
-              color: row[0].color,
-              ignore: row[0].ignore
-            };
-          } else {
-            responseData = row[0]; // Default behavior if HideCapcode is false
-          }
+        if (HideCapcode && (!req.isAuthenticated() || (req.isAuthenticated() && req.user.role === 'user'))) {
+          responseData = {
+            id: row[0].id,
+            message: row[0].message,
+            source: row[0].source,
+            datetime: row[0].timestamp,
+            timestamp: row[0].timestamp,
+            alias_id: row[0].alias_id,
+            alias: row[0].alias,
+            agency: row[0].agency,
+            icon: row[0].icon,
+            color: row[0].color,
+            ignore: row[0].ignore,
+          };
         } else {
           responseData = row[0];
         }
@@ -551,7 +540,7 @@ router.route('/messageSearch')
 
     var data = []
     console.time('sql')
-    db.select('messages.*', 'capcodes.alias', 'capcodes.agency', 'capcodes.icon', 'capcodes.color', 'capcodes.ignore', db.raw('CASE WHEN NOT capcodes.address = messages.address THEN 1 ELSE 0 END as wildcard'))
+    db.select('messages.*', 'capcodes.alias', 'capcodes.agency', 'capcodes.icon', 'capcodes.color', 'capcodes.ignore', 'capcodes.hideMessages', db.raw('CASE WHEN NOT capcodes.address = messages.address THEN 1 ELSE 0 END as wildcard'))
       .modify(function (qb) {
         if (dbtype == 'sqlite3' && query != '') {
           qb.from('messages_search_index')
@@ -608,19 +597,20 @@ router.route('/messageSearch')
                   "agency": row.agency,
                   "icon": row.icon,
                   "color": row.color,
-                  "ignore": row.ignore
+                  "ignore": row.ignore,
+                  "hiddeMessages": row.hideMessages,
                 };
               }
             }
             if (pdwMode) {
-              if (adminShow && req.isAuthenticated() && req.user.role == 'admin' && !row.ignore || row.ignore == 0) {
+              if (adminShow && req.isAuthenticated() && req.user.role == 'admin' && (!row.ignore || row.ignore == 0) && (!row.hideMessages || row.hideMessages == 0)) {
                 data.push(row);
               } else {
-                if (row.ignore == 0)
+                if (row.ignore == 0 && row.hideMessages == 0)
                   data.push(row);
               }
             } else {
-              if (!row.ignore || row.ignore == 0)
+              if ((!row.ignore || row.ignore == 0) && (!row.hideMessages || row.hideMessages == 0))
                 data.push(row);
             }
           }
@@ -719,6 +709,7 @@ router.route('/capcodes')
       var color = req.body.color || 'black';
       var icon = req.body.icon || 'question';
       var ignore = req.body.ignore || 0;
+      var hideMessages = req.body.hideMessages || 0;
       const pluginconf = JSON.stringify(vaccumPluginConf(req.body.pluginconf)) || "{}";
       const onlyShowLoggedIn = req.body.onlyShowLoggedIn || false;
       db.from('capcodes')
@@ -733,6 +724,7 @@ router.route('/capcodes')
               color,
               icon,
               ignore,
+              hideMessages,
               pluginconf,
               onlyShowLoggedIn,
             })
@@ -745,6 +737,7 @@ router.route('/capcodes')
               color,
               icon,
               ignore,
+              hideMessages,
               pluginconf,
               onlyShowLoggedIn,
             })
@@ -808,6 +801,7 @@ router.route('/capcodes/:id')
       "icon": "question",
       "color": "black",
       "ignore": 0,
+      "hideMessages": 0,
       "pluginconf": {},
       "onlyShowLoggedIn": false,
     };
@@ -871,6 +865,7 @@ router.route('/capcodes/:id')
         var color = req.body.color || 'black';
         var icon = req.body.icon || 'question';
         var ignore = req.body.ignore || 0;
+        var hideMessages = req.body.hideMessages || 0;
         var pluginconf = JSON.stringify(vaccumPluginConf(req.body.pluginconf)) || "{}";
         var updateAlias = req.body.updateAlias || 0;
         const onlyShowLoggedIn = req.body.onlyShowLoggedIn || 0;
@@ -889,6 +884,7 @@ router.route('/capcodes/:id')
                 color,
                 icon,
                 ignore,
+                hideMessages,
                 pluginconf,
                 onlyShowLoggedIn
               })
@@ -901,6 +897,7 @@ router.route('/capcodes/:id')
                 color,
                 icon,
                 ignore,
+                hideMessages,
                 pluginconf,
                 onlyShowLoggedIn
               })
@@ -1018,6 +1015,7 @@ router.route('/capcodeCheck/:id')
             "icon": "question",
             "color": "black",
             "ignore": 0,
+            "hideMessages": 0,
             "pluginconf": {},
             "onlyShowLoggedIn": 0
           };
@@ -1109,6 +1107,7 @@ router.route('/capcodeImport')
             var color = capcode.color || 'black';
             var icon = capcode.icon || 'question';
             var ignore = capcode.ignore || 0;
+            var hideMessages = capcode.hideMessages || 0;
             const  pluginconf = JSON.stringify(vaccumPluginConf(capcode.pluginconf)) || "{}";
             const onlyShowLoggedIn = capcode.onlyShowLoggedIn || false;
             await db('capcodes')
@@ -1127,6 +1126,7 @@ router.route('/capcodeImport')
                       color,
                       icon,
                       ignore,
+                      hideMessages,
                       pluginconf,
                       onlyShowLoggedIn,
                     })
@@ -1154,6 +1154,7 @@ router.route('/capcodeImport')
                     color,
                     icon,
                     ignore,
+                    hideMessages,
                     pluginconf,
                     onlyShowLoggedIn,
                   })

--- a/server/test/routes.api.capcodes.test.js
+++ b/server/test/routes.api.capcodes.test.js
@@ -49,7 +49,8 @@ describe('GET /api/capcodes', () => {
                 res.body[0].should.have.property('color')
                 res.body[0].should.have.property('pluginconf')
                 res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(6)
+                res.body[0].should.have.property('hideMessages')
+                res.body.length.should.eql(7)
                 done();
             });
     });
@@ -70,7 +71,8 @@ describe('GET /api/capcodes', () => {
                 res.body[0].should.have.property('color')
                 res.body[0].should.have.property('pluginconf')
                 res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(6)
+                res.body[0].should.have.property('hideMessages')
+                res.body.length.should.eql(7)
                 done();
             });
     });
@@ -142,6 +144,8 @@ describe('GET /api/capcodes/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -172,6 +176,8 @@ describe('GET /api/capcodes/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -198,6 +204,8 @@ describe('GET /api/capcodes/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -224,6 +232,8 @@ describe('GET /api/capcodes/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -345,7 +355,7 @@ describe('GET /api/capcodes/agency', () => {
                 res.type.should.eql('application/json');
                 res.body.should.be.a('array');
                 res.body[0].should.have.property('agency')
-                res.body.length.should.eql(6)
+                res.body.length.should.eql(7)
                 done();
             });
     });
@@ -359,7 +369,7 @@ describe('GET /api/capcodes/agency', () => {
                 res.type.should.eql('application/json');
                 res.body.should.be.a('array');
                 res.body[0].should.have.property('agency')
-                res.body.length.should.eql(6)
+                res.body.length.should.eql(7)
                 done();
             });
     });
@@ -528,6 +538,8 @@ describe('GET /api/capcodeCheck/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -558,6 +570,8 @@ describe('GET /api/capcodeCheck/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -584,6 +598,8 @@ describe('GET /api/capcodeCheck/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });
@@ -610,6 +626,8 @@ describe('GET /api/capcodeCheck/:id', () => {
                                 res.body.should.have.property('pluginconf');
                                 res.body.should.have.property('ignore');
                                 res.body.ignore.should.eql(0);
+                                res.body.should.have.property('hideMessages');
+                                res.body.hideMessages.should.eql(0);
                                 done();
                         });
         });

--- a/server/test/routes.api.messages.id.test.js
+++ b/server/test/routes.api.messages.id.test.js
@@ -112,6 +112,34 @@ describe('GET /api/messages/id', () => {
                                 done();
                         });
         });
+        it('should not return message for hidden alias if not logged in ', done => {
+                chai.request(server)
+                        .get('/api/messages/8')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.eql({});
+                                done();
+                        });
+        });
+        it('should not return message for hidden alias if logged in', done => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                });
+                chai.request(server)
+                .get('/api/messages/8')
+                .end((err, res) => {
+                        should.not.exist(err);
+                        res.status.should.eql(200);
+                        res.type.should.eql('application/json');
+                        res.body.should.be.a('object');
+                        res.body.should.eql({});
+                        done();
+                });
+        });
         it('should 401 if securemode is enabled and not logged in ', done => {
                 nconf.set('messages:apiSecurity', true);
                 nconf.save();

--- a/server/test/routes.api.messages.test.js
+++ b/server/test/routes.api.messages.test.js
@@ -54,7 +54,7 @@ describe('POST /api/messages', () => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('text/html');
-                                res.text.should.be.eql('8');
+                                res.text.should.be.eql('9');
                                 done();
                         });
         });

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -88,10 +88,10 @@ describe('GET /api/messageSearch', () => {
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.messages[0].should.have.property('address').eql('1234572');
+                                res.body.messages[0].should.have.property('address').eql('1234573');
                                 res.body.messages[0].should.have
                                         .property('message')
-                                        .eql('This is a Test Message to non-stored Address 1234572');
+                                        .eql('This is a Test Message to non-stored Address 1234573');
                                 res.body.messages[0].should.have.property('source').eql('Client 5');
                                 done();
                         });

--- a/server/themes/default/public/templates/admin/aliasDetails.html
+++ b/server/themes/default/public/templates/admin/aliasDetails.html
@@ -162,15 +162,27 @@
               </div>
               </div>
             </div>
-            <div class="form-group" ng-class="{'has-warning':alias.ignore == 1}">
-              <label for="alias.onlyShowLoggedIn" class="col-xs-4 col-sm-3 control-label">Hide Alias</label>
+            <div class="form-group" ng-class="{'has-warning':alias.onlyShowLoggedIn == 1}">
+              <label for="alias.onlyShowLoggedIn" class="col-xs-4 col-sm-3 control-label">Hide to anonymous</label>
               <div class="col-xs-8 col-sm-9">
               <div class="checkbox">
                 <label>
-                <input type="checkbox" name="alias.onlyShowLoggedIn" id="aliasHide" ng-model="alias.onlyShowLoggedIn" ng-true-value="1" ng-false-value="0">
+                <input type="checkbox" name="alias.onlyShowLoggedIn" id="aliasOnlyShowLoggedIn" ng-model="alias.onlyShowLoggedIn" ng-true-value="1" ng-false-value="0">
                 Show only for logged-in users
                 </label>
                 <span id="helpBlock" class="help-block">Messages for that alias will only be shown to users that are logged in and will be hidden for everyone else.</span>
+              </div>
+              </div>
+            </div>
+            <div class="form-group" ng-class="{'has-warning':alias.hideMessages == 1}">
+              <label for="alias.hideMessages" class="col-xs-4 col-sm-3 control-label">Hide to everyone</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="alias.hideMessages" id="aliasHideMessages" ng-model="alias.hideMessages" ng-true-value="1" ng-false-value="0">
+                Hide from everyone
+                </label>
+                <span id="helpBlock" class="help-block">Messages for that alias will be stored in the database and processed by plugins, but hidden for everyone.</span>
               </div>
               </div>
             </div>


### PR DESCRIPTION
# Description
Sometimes you want to store and process messages, but don't show them in the gui. This feature enables you to hide messages belonging to a certain capcode from everyone, including logged-in users and admins. They will however still be stored in the db and sent to all plugins.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] CI Test complete successfull
- [X] New tests added
- [X] Local test bench showed no errors and feature working fine

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



