### PR TITLE
Hotfix: DB Query Quotes

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -289,7 +289,7 @@ router.route('/messages')
               db.from('capcodes')
                 .select('id', 'ignore')
                 .whereRaw(`? LIKE ??`, [address, 'address'])
-                .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address']);
+                .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address'])
                 .then((row) => {
                   var insert;
                   var alias_id = null;
@@ -593,7 +593,7 @@ router.route('/messageSearch')
           qb.whereRaw(`CONTAINS("messages"."message", ?, 1) > 0`, query)
         } else {
           if (address != '')
-            qb.whereLike('messages.address', address).orWhere('messages.source', address);
+            qb.where('messages.address', 'LIKE', address).orWhere('messages.source', address);
           if (agency != '')
             qb.whereIn('messages.alias_id', function (qb2) {
               qb2.select('id').from('capcodes').where('agency', agency).where('ignore', 0);
@@ -789,7 +789,7 @@ router.route('/capcodes/agency/:id')
     var id = req.params.id;
     db.from('capcodes')
       .select('*')
-      .whereLike('agency', id)
+      .where('agency', 'LIKE', id)
       .then((rows) => {
         res.status(200);
         res.json(rows);
@@ -913,8 +913,8 @@ router.route('/capcodes/:id')
                 .update('alias_id', function () {
                   this.select('id')
                     .from('capcodes')
-                    .whereLike('messages.address', 'address')
-                    .orderByRaw(`REPLACE(??, '_', '%') DESC`, 'address');
+                    .where('messages.address', 'LIKE', 'address')
+                    .orderByRaw(`REPLACE(??, '_', '%') DESC`, 'address')
                     .limit(1)
                 })
                 .catch((err) => {
@@ -932,7 +932,7 @@ router.route('/capcodes/:id')
                 db('messages').update('alias_id', function () {
                   this.select('id')
                     .from('capcodes')
-                    .whereLike(db.ref('messages.address'), db.ref('capcodes.address'))
+                    .where('messages.address', 'LIKE', db.ref('capcodes.address'))
                     .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address']) 
                     .limit(1)
                 })
@@ -1027,7 +1027,7 @@ router.route('/capcodeRefresh')
     db('messages').update('alias_id', function () {
       this.select('id')
         .from('capcodes')
-        .whereLike(db.ref('messages.address'), db.ref('capcodes.address'))
+        .where('messages.address', 'LIKE', db.ref('capcodes.address'))
         .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address'])
         .limit(1)
     })

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -288,16 +288,8 @@ router.route('/messages')
             } else {
               db.from('capcodes')
                 .select('id', 'ignore')
-                // TODO: test this doesn't break other DBs - there's a lot of quote changes here
-                .modify(function (queryBuilder) {
-                  if (dbtype == 'oracledb') {
-                    queryBuilder.whereRaw(`'${address}' LIKE "address"`)
-                    queryBuilder.orderByRaw(`REPLACE("address", '_', '%') DESC`);
-                  } else {
-                    queryBuilder.whereRaw(`"${address}" LIKE address`)
-                    queryBuilder.orderByRaw(`REPLACE(address, '_', '%') DESC`)
-                  }
-                })
+                .whereRaw(`? LIKE ??`, [address, 'address'])
+                .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address']);
                 .then((row) => {
                   var insert;
                   var alias_id = null;
@@ -601,7 +593,7 @@ router.route('/messageSearch')
           qb.whereRaw(`CONTAINS("messages"."message", ?, 1) > 0`, query)
         } else {
           if (address != '')
-            qb.where('messages.address', 'LIKE', address).orWhere('messages.source', address);
+            qb.whereLike('messages.address', address).orWhere('messages.source', address);
           if (agency != '')
             qb.whereIn('messages.alias_id', function (qb2) {
               qb2.select('id').from('capcodes').where('agency', agency).where('ignore', 0);
@@ -711,12 +703,7 @@ router.route('/capcodes')
     var dbtype = nconf.get('database:type');
     db.from('capcodes')
       .select('*')
-      .modify(function (queryBuilder) {
-        if (dbtype == 'oracledb')
-          queryBuilder.orderByRaw(`REPLACE("address", '_', '%')`);
-        else
-          queryBuilder.orderByRaw(`REPLACE(address, '_', '%')`)
-      })
+      .orderByRaw(`REPLACE(??, '_', '%')`, ['address'])
       .then((rows) => {
         res.json(rows);
       })
@@ -802,7 +789,7 @@ router.route('/capcodes/agency/:id')
     var id = req.params.id;
     db.from('capcodes')
       .select('*')
-      .where('agency', 'like', id)
+      .whereLike('agency', id)
       .then((rows) => {
         res.status(200);
         res.json(rows);
@@ -926,13 +913,8 @@ router.route('/capcodes/:id')
                 .update('alias_id', function () {
                   this.select('id')
                     .from('capcodes')
-                    .where('messages.address', 'like', 'address')
-                    .modify(function (queryBuilder) {
-                      if (dbtype == 'oracledb')
-                        queryBuilder.orderByRaw(`REPLACE("address", '_', '%') DESC`);
-                      else
-                        queryBuilder.orderByRaw(`REPLACE(address, '_', '%') DESC`)
-                    })
+                    .whereLike('messages.address', 'address')
+                    .orderByRaw(`REPLACE(??, '_', '%') DESC`, 'address');
                     .limit(1)
                 })
                 .catch((err) => {
@@ -950,14 +932,9 @@ router.route('/capcodes/:id')
                 db('messages').update('alias_id', function () {
                   this.select('id')
                     .from('capcodes')
-                    .where(db.ref('messages.address'), 'like', db.ref('capcodes.address'))
-                    .modify(function (queryBuilder) {
-                      if (dbtype == 'oracledb')
-                        queryBuilder.orderByRaw(`REPLACE("address", '_', '%') DESC`);
-                      else
-                        queryBuilder.orderByRaw(`REPLACE(address, '_', '%') DESC`)
-                  })
-                  .limit(1)
+                    .whereLike(db.ref('messages.address'), db.ref('capcodes.address'))
+                    .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address']) 
+                    .limit(1)
                 })
                 .where(db.ref('messages.address'), '=', req.body.address)
                 .catch((err) => {
@@ -1050,13 +1027,8 @@ router.route('/capcodeRefresh')
     db('messages').update('alias_id', function () {
       this.select('id')
         .from('capcodes')
-        .where(db.ref('messages.address'), 'like', db.ref('capcodes.address'))
-        .modify(function (queryBuilder) {
-          if (dbtype == 'oracledb')
-            queryBuilder.orderByRaw(`REPLACE("address", '_', '%') DESC`);
-          else
-            queryBuilder.orderByRaw(`REPLACE(address, '_', '%') DESC`)
-        })
+        .whereLike(db.ref('messages.address'), db.ref('capcodes.address'))
+        .orderByRaw(`REPLACE(??, '_', '%') DESC`, ['address'])
         .limit(1)
     })
       .then((result) => {
@@ -1078,12 +1050,7 @@ router.route('/capcodeExport')
     var filename = 'export.csv'
     db.from('capcodes')
       .select('*')
-      .modify(function (queryBuilder) {
-        if (dbtype == 'oracledb')
-          queryBuilder.orderByRaw(`REPLACE("address", '_', '%')`);
-        else
-          queryBuilder.orderByRaw(`REPLACE(address, '_', '%')`)
-      })
+      .orderByRaw(`REPLACE(??, '_', '%')`, ['address'])
       .then((rows) => {
         converter.json2csv(rows, function (err, data) {
           if (err) {


### PR DESCRIPTION
# Description
We relied a lot on JavaScript control structures depending on the dbtype, to manually choose the right quotes for our queries. Knex offers some convenience functions like "db.ref()" and Query Bindings, that should automatically choose the right quotes depending on the used database adapter.

This should fix issues where wrong quotes lead to errors like #628 and make our code slightly slimmer and less error prone - although there's a LOT room for improvement 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] CI-Tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made