### PR TITLE
Fix index page with enabled apiSecurity

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -33,6 +33,7 @@ router.get('/', function (req, res, next) {
     if (nconf.get('messages:apiSecurity') && !req.isAuthenticated()) {
         req.flash('loginMessage', 'You need to be logged in to access this page');
         res.redirect('/auth/login');
+        return;
     }
 
     res.render('index', { pageTitle: 'Home' });


### PR DESCRIPTION
# Description
When apiSecurity is enabled and the index page is requested without being logged in, a headers already sent error was generated. This PR adds a return statement.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



