### PR TITLE
Feature: Choose shell in Shell Plugin - Testers wanted

### DIFF
--- a/server/plugins/Shell.js
+++ b/server/plugins/Shell.js
@@ -1,59 +1,54 @@
-var spawn = require("child_process").spawn;
+var { spawn } = require('child_process');
 var fs = require('fs');
 var logger = require('../log');
 
-
 function run(trigger, scope, data, config, callback) {
+        if (!data.plubincon.Shell || !data.pluginconf.Shell.enable) return callback(DataTransferItem);
 
-  if(data.pluginconf.Shell && data.pluginconf.Shell.enable){
-    
-    var file_name = data.alias_id;
+        // Override ID if needed
+        const fileName = data.pluginconf.Shell.overrideAlias > 0 ? data.pluginconf.Shell.overrideAlias : data.alias_id;
+        if (data.pluginconf.Shell.overrideAlias > 0) logger.main.debug('Override filename');
 
-    // Override ID if needed
-    if(data.pluginconf.Shell.overrideAlias > 0){
-      logger.main.debug('Override filename');
-      var file_name = data.pluginconf.Shell.overrideAlias;
-    }
+        const filePath =
+                process.platform === 'win32' ? `${process.cwd()}\\plugins\\Shell\\` : `${process.cwd()}/plugins/Shell/`;
+        const fullFileName = process.platform === 'win32' ? `${fileName}.ps1` : `${fileName}.sh`;
 
-    if(process.platform === "win32"){
-      // Windows platform, Win 64bits too
-      var file_path = process.cwd()+'\\plugins\\Shell\\';
-      var full_file_name = file_name+'.ps1';
-    }else{
-      // Others, 'aix', 'darwin', 'freebsd', 'linux', 'openbsd', 'sunos'
-      var file_path = process.cwd()+'/plugins/Shell/';
-      var full_file_name = file_name+'.sh';
-    }
+        const shell = data.pluginconf.Shell.shell || process.platform === 'win32' ? 'powershell.exe' : 'sh';
+        if (process.platform === 'win32' && shell !== 'powershell.exe')
+                return logger.main.error('Shell must be powershell.exe on Windows');
+        if (process.platform !== 'win32' && shell === 'powershell.exe')
+                return logger.main.error('Powershell is only available on Windows');
 
-    // Check file exist
-    if(fs.existsSync(file_path+full_file_name)){
-        logger.main.info('Exec shell command for selected alias')
+        // Check file exist
+        if (!fs.existsSync(filePath + fullFileName)) return logger.main.info(`File ${fullFileName} not exist`);
 
-        if(process.platform === "win32"){
-          var child = spawn("powershell.exe", [file_path+full_file_name, '"'+data.address+'"', "@'\r\n"+data.message+"\r\n'@", "@'\r\n"+JSON.stringify(data)+"\r\n'@"]); //
-        }else{
-          var child = spawn("sh", [file_path+full_file_name, data.address, data.message, JSON.stringify(data)]);
-        }
+        logger.main.info('Exec shell command for selected alias');
 
-        child.stdout.on("data",function(data){
-            logger.main.debug("ShellScript Data: " + data);
+        const child =
+                shell === 'powershell.exe'
+                        ? spawn('powershell.exe', [
+                                  filePath + fullFileName,
+                                  `"${data.address}"`,
+                                  `@'\r\n${data.message}\r\n'@`,
+                                  `@'\r\n${JSON.stringify(data)}\r\n'@`,
+                          ])
+                        : spawn(shell, [filePath + fullFileName, data.address, data.message, JSON.stringify(data)]);
+
+        child.stdout.on('data', function(innerData) {
+                logger.main.debug(`ShellScript Data: ${innerData}`);
         });
-        child.stderr.on("data",function(data){
-            logger.main.error("ShellScript Errors: " + data);
+        child.stderr.on('data', function(innerData) {
+                logger.main.error(`ShellScript Errors: ${innerData}`);
         });
-        child.on("exit",function(code){ // Exit code, ok = 0
-            logger.main.info("ShellScript finished");
+        child.on('exit', function(code) {
+                // Exit code, ok = 0
+                logger.main.info('ShellScript finished');
         });
-        child.stdin.end(); //end input
+        child.stdin.end(); // end input
 
-    }else{
-      logger.main.info('File '+full_file_name+' not exist');
-    }
-  }
-  
-  callback(data);
+        callback(data);
 }
 
 module.exports = {
-    run: run
-}
+        run,
+};

--- a/server/plugins/Shell.js
+++ b/server/plugins/Shell.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
-        if (!data.plubincon.Shell || !data.pluginconf.Shell.enable) return callback(DataTransferItem);
+        if (!data.plubincon.Shell || !data.pluginconf.Shell.enable) return callback(data);
 
         // Override ID if needed
         const fileName = data.pluginconf.Shell.overrideAlias > 0 ? data.pluginconf.Shell.overrideAlias : data.alias_id;
@@ -14,13 +14,20 @@ function run(trigger, scope, data, config, callback) {
         const fullFileName = process.platform === 'win32' ? `${fileName}.ps1` : `${fileName}.sh`;
 
         const shell = data.pluginconf.Shell.shell || process.platform === 'win32' ? 'powershell.exe' : 'sh';
-        if (process.platform === 'win32' && shell !== 'powershell.exe')
-                return logger.main.error('Shell must be powershell.exe on Windows');
-        if (process.platform !== 'win32' && shell === 'powershell.exe')
-                return logger.main.error('Powershell is only available on Windows');
+        if (process.platform === 'win32' && shell !== 'powershell.exe') {
+                logger.main.error('Shell must be powershell.exe on Windows');
+                return callback(data);
+        }
+        if (process.platform !== 'win32' && shell === 'powershell.exe') {
+                logger.main.error('Powershell is only available on Windows');
+                return callback(data);
+        }
 
         // Check file exist
-        if (!fs.existsSync(filePath + fullFileName)) return logger.main.info(`File ${fullFileName} not exist`);
+        if (!fs.existsSync(filePath + fullFileName)) {
+                logger.main.info(`File ${fullFileName} not exist`);
+                return callback(data);
+        }
 
         logger.main.info('Exec shell command for selected alias');
 

--- a/server/plugins/Shell.json
+++ b/server/plugins/Shell.json
@@ -18,6 +18,17 @@
             "label": "Override Alias",
             "description": "Overwrite filename. Use another aliases script for this alias - enter the ID of the corresponding alias.",
             "type": "number"
+        },
+        {
+            "name": "shell",
+            "label": "Shell",
+            "description": "Choose, which shell to use for this alias. Default is \"sh\".",
+            "type": "select",
+            "options": [
+                {"value": "sh", "text": "Shell"},
+                {"value": "bash", "text": "Bash"},
+                {"value": "powershell", "text": "PowerShell (Only available on Windows systems)"}
+            ]
         }
     ]
 }


### PR DESCRIPTION
# Description
Issue #620 requests the shell plugin to support `bash`. This PR adds an option to set the bash.
Due to the nature of plugin configurations it is not possible to restrain the choosable shells to the available shells.
However, the plugin errors, if powershell is set on non-windows systems or sh/bash is set on windows systems.
It defaults to powershell on windows and sh on linux.

The plugin is not yet tested!

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



