### PR TITLE
647 only run docker build when tests pass

### DIFF
--- a/.github/workflows/Image-Build.yml
+++ b/.github/workflows/Image-Build.yml
@@ -3,50 +3,49 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - 'develop'
+      - master
+      - develop
     tags:
-      - 'v*.*.*'
+    - 'v*.*.*'
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
-  push_to_registry:
-    name: Build docker image and push it to Docker Hub
+  test:
     runs-on: ubuntu-latest
-    
+        
     steps:
-      - name: Set up Docker Build environment
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
-          install: true
-          
-      - name: Check out the repo
-        uses: actions/checkout@v4
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: pagermon/pagermon
-      
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          file: server/Dockerfile
-          context: ./server
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
 
-  push_to_registry_armhf:
-    name: Build ARMv7 Docker image and push it to Docker Hub
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      id: npm-cache
+      with:
+        path: ./server/node_modules
+        key: ${{ runner.os }}-node-22-${{ hashFiles('./server/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-22-
+          ${{ runner.os }}-node-
+          
+    - name: Install dependencies
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: npm install
+      working-directory: ./server
+      
+    - run: npm run test-text
+      working-directory: ./server
+
+  push_to_registry:
+    name: Build Docker image and push it to Docker Hub
     runs-on: ubuntu-latest
+    needs: test
     
     steps:
       - name: Set up QEMU
@@ -62,6 +61,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -72,14 +72,23 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: pagermon/pagermon
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
       
-      - name: Build and push Docker image - ARMHF
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          file: server/Dockerfile.armhf
+          file: server/Dockerfile
           context: ./server
-          platforms: linux/arm/v7
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}-armhf
+          platforms: linux/amd64, linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/Image-Build.yml
+++ b/.github/workflows/Image-Build.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    name: Run node 22 tests before building Docker image
     runs-on: ubuntu-latest
         
     steps:

--- a/.github/workflows/server.js.yml
+++ b/.github/workflows/server.js.yml
@@ -11,6 +11,7 @@ jobs:
   Run_Tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: ['18.x', '20.x', '22.x', 'latest']
         


### PR DESCRIPTION
# Description
Currently, the Docker Build always run - even if the tests fail.

Fixes #647 

# Content
The GitHub Action requires passing tests (only for the node version used for the build) before building Docker images. Additionally, the multi platform build is be performed in one instead of two steps, as this is possible now. Additionally, new tags are be attached to the images, including semver.

On a second note, the node-js tests are changed to not abort, if the test for one node version failed. This makes it possible to detect changes, that require a bump in minimum node version.

# Type of change
Chore


